### PR TITLE
Add support for major release selection

### DIFF
--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -89,6 +89,18 @@ describe('installer tests', () => {
         expect(fs.existsSync(path.join(goDir, 'bin', 'go'))).toBe(true);
       }
     }, 100000);
+
+    it('Acquires latest release version of go if using latest and matching version is installed', async () => {
+      await installer.getGo('latest');
+      const goDir = path.join(toolDir, 'go', '1.13.0', os.arch());
+
+      expect(fs.existsSync(`${goDir}.complete`)).toBe(true);
+      if (IS_WINDOWS) {
+        expect(fs.existsSync(path.join(goDir, 'bin', 'go.exe'))).toBe(true);
+      } else {
+        expect(fs.existsSync(path.join(goDir, 'bin', 'go'))).toBe(true);
+      }
+    }, 100000);
   });
 
   it('Throws if no location contains correct go version', async () => {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -167,6 +167,10 @@ function normalizeVersion(version: string): string {
 }
 
 async function determineVersion(version: string): Promise<string> {
+  if (version == 'latest') {
+    return await getLatestVersion('');
+  }
+
   if (!version.endsWith('.x')) {
     const versionPart = version.split('.');
 
@@ -188,7 +192,7 @@ async function getLatestVersion(version: string): Promise<string> {
 
   core.debug(`evaluating ${versions.length} versions`);
 
-  if (version.length === 0) {
+  if (versions.length === 0) {
     throw new Error('unable to get latest version');
   }
 


### PR DESCRIPTION
This PR adds 'latest' version alias that resolves to the latest available release.

The `getPossibleVersions` function filters using `startsWith(version)`, so calling `getLatestVersion(version)` with an empty string will return the latest release.

Closes #31.
