### PR TITLE
Add support for gotip and latest

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -5,6 +5,7 @@ jobs:
     name: Run
     runs-on: ${{ matrix.operating-system }}
     strategy:
+      fail-fast: false
       matrix:
         operating-system: [ubuntu-latest, windows-latest]
     steps:
@@ -14,13 +15,14 @@ jobs:
     - name: Set Node.js 10.x
       uses: actions/setup-node@master
       with:
-        version: 10.x
+        node-version: 10.x
 
     - name: npm install
       run: npm install
 
-    - name: Lint
-      run: npm run format-check
-
     - name: npm test
       run: npm test
+
+    - name: Lint
+      run: npm run format-check
+      continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 This action sets up a go environment for use in actions by:
 
 - optionally downloading and caching a version of Go by version and adding to PATH
+- optionally building and caching Go tip (master branch) from source
 - registering problem matchers for error output
 
 # Usage
@@ -30,7 +31,7 @@ jobs:
     runs-on: ubuntu-16.04
     strategy:
       matrix:
-        go: [ '1.8', '1.9.3', '1.10.x' ]
+        go: [ '1.8', '1.9.3', '1.10.x', 'latest', 'tip' ]
     name: Go ${{ matrix.go }} sample
     steps:
       - uses: actions/checkout@master

--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -25,6 +25,7 @@ beforeAll(cleanup, 100000);
 afterAll(cleanup, 100000);
 
 const describeTable = describe.each([
+  ['tip',    '+60f14fd', 'go1.13beta1', '60f14fddfee107dedd76c0be6b422a3d8ccc841a'],
   ['tip',    '+a5bfd9d', 'go1.14beta1', 'a5bfd9da1d1b24f326399b6b75558ded14514f23'],
   ['latest', 'go1.13',   'n/a',         '1.13.0'],
   ['1.x',    'go1.13',   'n/a',         '1.13.0'],
@@ -61,6 +62,14 @@ describeTable('Go %s (%s)', (version: string, goVersion: string, gitRef: string,
     const promise = installer.getGo(version, gitRef);
     await expect(promise).resolves.toBeUndefined();
   }, timeout);
+
+  if (gotip) {
+    const gitDir = path.join(toolDir, cacheDir, 'master', '');
+    test('git cache check', async () => {
+      const promise = fs.promises.access(gitDir);
+      await expect(promise).resolves.toBeUndefined();
+    });
+  }
 
   test('tool executable check', async () => {
     const promise = fs.promises.access(goTool);

--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -25,8 +25,8 @@ beforeAll(cleanup, 100000);
 afterAll(cleanup, 100000);
 
 const describeTable = describe.each([
-  ['tip',    '+60f14fd', 'go1.13beta1', '60f14fddfee107dedd76c0be6b422a3d8ccc841a'],
-  ['tip',    '+a5bfd9d', 'go1.14beta1', 'a5bfd9da1d1b24f326399b6b75558ded14514f23'],
+  ['tip',    '+60f14fd', 'go1.13beta1', '0.0.0-devel.60f14fddfee107dedd76c0be6b422a3d8ccc841a'],
+  ['tip',    '+a5bfd9d', 'go1.14beta1', '0.0.0-devel.a5bfd9da1d1b24f326399b6b75558ded14514f23'],
   ['latest', 'go1.13',   'n/a',         '1.13.0'],
   ['1.x',    'go1.13',   'n/a',         '1.13.0'],
   ['1.10.x', 'go1.10.8', 'n/a',         '1.10.8'],
@@ -64,14 +64,14 @@ describeTable('Go %s (%s)', (version: string, goVersion: string, gitRef: string,
   }, timeout);
 
   if (gotip) {
-    const gitDir = path.join(toolDir, cacheDir, 'master', '');
+    const gitDir = path.join(toolDir, cacheDir, '0.0.0-devel', 'noarch');
     test('git cache check', async () => {
       const promise = fs.promises.access(gitDir);
       await expect(promise).resolves.toBeUndefined();
     });
   }
 
-  test('tool executable check', async () => {
+  test('tool existence check', async () => {
     const promise = fs.promises.access(goTool);
     await expect(promise).resolves.toBeUndefined();
   });

--- a/src/executil.ts
+++ b/src/executil.ts
@@ -1,0 +1,80 @@
+import * as exec from '@actions/exec';
+
+export async function stdout(cmd: string, args: string[]): Promise<string> {
+  let s: string = '';
+  // For some strange reason, exec ignores process.env
+  // unless we pass it explicitly.
+  const env: { [key: string]: string } = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value === undefined) {
+      continue;
+    }
+    env[key] = value;
+  }
+  await exec.exec(cmd, args, {
+    env,
+    silent: true,
+    listeners: {
+      stdout: (buf: Buffer) => {
+        s += buf.toString();
+      },
+    },
+  });
+  return s;
+}
+
+export async function git(args: string[], opts?: any) {
+  let rc: number = await exec.exec('git', args, opts);
+  if (rc != 0) {
+    throw new Error(`git: exit code ${rc}`);
+  }
+}
+
+export async function gitClone(gitDir: string, gitRepo: string, workTree: string, ref: string) {
+  let args: string[] = [
+    'clone',
+    `--branch=${ref}`,
+    `--separate-git-dir=${gitDir}`,
+    '--depth=1',
+    '--',
+    gitRepo,
+    workTree,
+  ];
+  await git(args);
+}
+
+export async function gitFetch(gitDir: string) {
+  let args: string[] = [
+    `--git-dir=${gitDir}`,
+    'fetch',
+    '--depth=1',
+  ];
+  await git(args);
+}
+
+export async function gitRevParse(gitDir: string, spec: string): Promise<string> {
+  let args: string[] = [
+    `--git-dir=${gitDir}`,
+    'rev-parse',
+    '--verify',
+    spec,
+  ];
+  let hash = await stdout('git', args);
+  return hash.trim();
+}
+
+export async function gitReset(gitDir: string, workTree: string, spec: string) {
+  let args: string[] = [
+    `--git-dir=${gitDir}`,
+    `--work-tree=${workTree}`,
+    'reset',
+    '--hard',
+    spec,
+  ];
+  await git(args);
+}
+
+export async function goEnv(envVar: string, goExe: string = 'go'): Promise<string> {
+  let envVal = await stdout(goExe, ['env', '--', envVar]);
+  return envVal.trim();
+}

--- a/src/executil.ts
+++ b/src/executil.ts
@@ -43,11 +43,13 @@ export async function gitClone(gitDir: string, gitRepo: string, workTree: string
   await git(args);
 }
 
-export async function gitFetch(gitDir: string) {
+export async function gitFetch(gitDir: string, ref: string) {
   let args: string[] = [
     `--git-dir=${gitDir}`,
     'fetch',
     '--depth=1',
+    'origin',
+    ref,
   ];
   await git(args);
 }

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -99,7 +99,9 @@ async function acquireGo(version: string, gotipRef: string, bootstrapGo: string)
         if (!workTree) {
           // We found gotip.git in cache, but not the work tree.
           //
-          workTree = path.join(extPath, filename);
+          // Also append commit hash to prevent conflicts with
+          // other checkouts.
+          workTree = path.join(extPath, filename, commitHash);
           // Work tree must exist, otherwise Git will complain
           // that “this operation must be run in a work tree”.
           await io.mkdirP(workTree);
@@ -122,6 +124,10 @@ async function acquireGo(version: string, gotipRef: string, bootstrapGo: string)
         const env = {
           'GOROOT_BOOTSTRAP': bootstrap,
           ...process.env,
+          // Tell Git where to look for the repo. Git will be invoked
+          // by cmd/dist to find Go version and write VERSION file.
+          'GIT_DIR': gitDir,
+          'GIT_WORK_TREE': workTree,
           // Note that while we disable Cgo for tip builds, it does
           // not disable Cgo entirely. Moreover, we override this
           // value in setGoEnvironmentVariables with whatever the

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -112,8 +112,9 @@ async function acquireGo(version: string, gotipRef: string, bootstrapGo: string)
 
         // The make.bat script on Windows is not smart enough
         // to figure out the path to bootstrap Go toolchain.
-        // Make script will show descriptive error message even
-        // if we don’t find Go installation on the host.
+        // We have to spoonfeed it with GOROOT_BOOTSTRAP value.
+        // At least make script will show descriptive error message
+        // even if we don’t find Go installation on the host.
         let bootstrap: string = '';
         if (bootstrapGo) {
           bootstrap = await executil.goEnv('GOROOT', bootstrapGo);

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -186,7 +186,7 @@ function getFileName(version: string): string {
   const arch: string = arches[osArch] || arches['default'];
   let ext: string;
   if (version == 'tip') {
-    // Git work tree for tip builds does not have an externsion.
+    // Git work tree for tip builds does not have an extension.
     ext = '';
   } else if (osPlat == 'win32') {
     ext = '.zip';

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -85,7 +85,7 @@ async function acquireGo(version: string, gotipRef: string, bootstrapGo: string)
         workTree = '';
 
         // Cache hit for git dir, fetch new commits from upstream.
-        await executil.gitFetch(gitDir);
+        await executil.gitFetch(gitDir, gotipRef);
 
         // Extract latest commit hash.
         commitHash = await executil.gitRevParse(gitDir, 'FETCH_HEAD');

--- a/src/tempdir.ts
+++ b/src/tempdir.ts
@@ -1,0 +1,26 @@
+// See https://github.com/actions/toolkit/blob/17acd9c66fb3dd360ef8c65fcd7c3b864064b5c7/packages/tool-cache/src/tool-cache.ts#L20-L45
+
+import * as path from 'path';
+import * as io from '@actions/io';
+
+export function tempDir(): string {
+  let tempDirectory: string = process.env['RUNNER_TEMP'] || '';
+  if (!tempDirectory) {
+    let baseLocation: string;
+    if (process.platform === 'win32') {
+      // On windows use the USERPROFILE env variable.
+      baseLocation = process.env['USERPROFILE'] || 'C:\\';
+    } else {
+      if (process.platform === 'darwin') {
+        baseLocation = '/Users';
+      } else {
+        baseLocation = '/home';
+      }
+    }
+    if (!tempDirectory) {
+      tempDirectory = path.join(baseLocation, 'actions', 'temp');
+    }
+  }
+  io.mkdirP(tempDirectory);
+  return tempDirectory;
+}


### PR DESCRIPTION
This PR adds support for building Go `tip` from source and an alias `latest` for the major release.

Closes #21
Closes #31
Closes #32
Closes #35