### PR TITLE
Add $GOBIN

### DIFF
--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -19,26 +19,26 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: setup-go ^1.13.6
+    - name: setup-go ^1.14.0
       uses: ./
       with:
-        go-version: ^1.13.6
+        go-version: ^1.14.0
 
-    - name: validate version 
-      run: go version | grep "go1.13."
+    - name: validate version
+      run: go version | grep "go1.14."
 
     - name: setup-go 1.13
       uses: ./
       with:
         go-version: 1.13
 
-    - name: validate version 
-      run: go version | grep "go1.13."      
+    - name: validate version
+      run: go version | grep "go1.13."
 
     - name: setup-go 1.12.9
       uses: ./
       with:
         go-version: 1.12.9
 
-    - name: validate version 
+    - name: validate version
       run: go version | grep "go1.12.9"

--- a/__tests__/gobin.test.ts
+++ b/__tests__/gobin.test.ts
@@ -6,12 +6,12 @@ jest.mock('child_process');
 describe('gobin', () => {
   const childProcess = require('child_process');
 
-  let execSpy: jest.SpyInstance;
+  let execFileSpy: jest.SpyInstance;
   let gopath = path.join('home', 'user', 'go');
 
   beforeEach(() => {
-    execSpy = jest.spyOn(childProcess, 'exec');
-    execSpy.mockImplementation((_command, callback) => {
+    execFileSpy = jest.spyOn(childProcess, 'execFile');
+    execFileSpy.mockImplementation((_file, _args, callback) => {
       callback('', {stdout: gopath, stderr: ''});
     });
   });

--- a/__tests__/gobin.test.ts
+++ b/__tests__/gobin.test.ts
@@ -20,4 +20,12 @@ describe('gobin', () => {
     const gobinPath = await gobin.getGOBIN('...');
     expect(gobinPath).toBe(path.join(gopath, 'bin'));
   });
+
+  it('should trim ${GOPATH} before using it', async () => {
+    let trimmed = gopath;
+    gopath = `${gopath}\r\n`;
+
+    const gobinPath = await gobin.getGOBIN('...');
+    expect(gobinPath).toBe(path.join(trimmed, 'bin'));
+  });
 });

--- a/__tests__/gobin.test.ts
+++ b/__tests__/gobin.test.ts
@@ -1,0 +1,21 @@
+import * as gobin from '../src/gobin';
+
+jest.mock('child_process');
+
+describe('gobin', () => {
+  const childProcess = require('child_process');
+
+  let execSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    execSpy = jest.spyOn(childProcess, 'exec');
+    execSpy.mockImplementation((_command, callback) => {
+      callback('', {stdout: '/home/user/go', stderr: ''});
+    });
+  });
+
+  it('should return ${GOPATH}/bin', async () => {
+    const gobinPath = await gobin.getGOBIN('...');
+    expect(gobinPath).toBe('/home/user/go/bin');
+  });
+});

--- a/__tests__/gobin.test.ts
+++ b/__tests__/gobin.test.ts
@@ -1,4 +1,5 @@
 import * as gobin from '../src/gobin';
+import * as path from 'path';
 
 jest.mock('child_process');
 
@@ -6,16 +7,17 @@ describe('gobin', () => {
   const childProcess = require('child_process');
 
   let execSpy: jest.SpyInstance;
+  let gopath = path.join('home', 'user', 'go');
 
   beforeEach(() => {
     execSpy = jest.spyOn(childProcess, 'exec');
     execSpy.mockImplementation((_command, callback) => {
-      callback('', {stdout: '/home/user/go', stderr: ''});
+      callback('', {stdout: gopath, stderr: ''});
     });
   });
 
   it('should return ${GOPATH}/bin', async () => {
     const gobinPath = await gobin.getGOBIN('...');
-    expect(gobinPath).toBe('/home/user/go/bin');
+    expect(gobinPath).toBe(path.join(gopath, 'bin'));
   });
 });

--- a/dist/index.js
+++ b/dist/index.js
@@ -1279,6 +1279,7 @@ const core = __importStar(__webpack_require__(470));
 const tc = __importStar(__webpack_require__(533));
 const installer = __importStar(__webpack_require__(749));
 const path = __importStar(__webpack_require__(622));
+const gobin = __importStar(__webpack_require__(517));
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
@@ -1302,6 +1303,9 @@ function run() {
                     core.exportVariable('GOROOT', installDir);
                     core.addPath(path.join(installDir, 'bin'));
                     console.log('Added go to the path');
+                    const gobinDir = yield gobin.getGOBIN(installDir);
+                    core.exportVariable('GOBIN', gobinDir);
+                    core.addPath(gobinDir);
                 }
                 else {
                     throw new Error(`Could not find a version that satisfied version spec: ${versionSpec}`);
@@ -3244,6 +3248,44 @@ function getState(name) {
 }
 exports.getState = getState;
 //# sourceMappingURL=core.js.map
+
+/***/ }),
+
+/***/ 517:
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const childProcess = __importStar(__webpack_require__(129));
+const path = __importStar(__webpack_require__(622));
+const util_1 = __webpack_require__(669);
+const exec = util_1.promisify(childProcess.exec);
+function getGOBIN(installDir) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const goExecutable = path.join(installDir, 'bin', 'go');
+        const result = yield exec(`${goExecutable} env GOPATH`);
+        const gopath = result.stdout;
+        return path.join(gopath, 'bin');
+    });
+}
+exports.getGOBIN = getGOBIN;
+
 
 /***/ }),
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -3280,7 +3280,7 @@ function getGOBIN(installDir) {
     return __awaiter(this, void 0, void 0, function* () {
         const goExecutable = path.join(installDir, 'bin', 'go');
         const result = yield execFile(goExecutable, ['env', 'GOPATH']);
-        const gopath = result.stdout;
+        const gopath = result.stdout.replace(/\s+$/, '');
         return path.join(gopath, 'bin');
     });
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -3275,11 +3275,11 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const childProcess = __importStar(__webpack_require__(129));
 const path = __importStar(__webpack_require__(622));
 const util_1 = __webpack_require__(669);
-const exec = util_1.promisify(childProcess.exec);
+const execFile = util_1.promisify(childProcess.execFile);
 function getGOBIN(installDir) {
     return __awaiter(this, void 0, void 0, function* () {
         const goExecutable = path.join(installDir, 'bin', 'go');
-        const result = yield exec(`${goExecutable} env GOPATH`);
+        const result = yield execFile(goExecutable, ['env', 'GOPATH']);
         const gopath = result.stdout;
         return path.join(gopath, 'bin');
     });

--- a/src/gobin.ts
+++ b/src/gobin.ts
@@ -2,12 +2,12 @@ import * as childProcess from 'child_process';
 import * as path from 'path';
 import {promisify} from 'util';
 
-const exec = promisify(childProcess.exec);
+const execFile = promisify(childProcess.execFile);
 
 export async function getGOBIN(installDir: string): Promise<string> {
   const goExecutable = path.join(installDir, 'bin', 'go');
 
-  const result = await exec(`${goExecutable} env GOPATH`);
+  const result = await execFile(goExecutable, ['env', 'GOPATH']);
   const gopath = result.stdout;
   return path.join(gopath, 'bin');
 }

--- a/src/gobin.ts
+++ b/src/gobin.ts
@@ -1,0 +1,13 @@
+import * as childProcess from 'child_process';
+import * as path from 'path';
+import {promisify} from 'util';
+
+const exec = promisify(childProcess.exec);
+
+export async function getGOBIN(installDir: string): Promise<string> {
+  const goExecutable = path.join(installDir, 'bin', 'go');
+
+  const result = await exec(`${goExecutable} env GOPATH`);
+  const gopath = result.stdout;
+  return path.join(gopath, 'bin');
+}

--- a/src/gobin.ts
+++ b/src/gobin.ts
@@ -8,6 +8,6 @@ export async function getGOBIN(installDir: string): Promise<string> {
   const goExecutable = path.join(installDir, 'bin', 'go');
 
   const result = await execFile(goExecutable, ['env', 'GOPATH']);
-  const gopath = result.stdout;
+  const gopath = result.stdout.replace(/\s+$/, '');
   return path.join(gopath, 'bin');
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import * as core from '@actions/core';
 import * as tc from '@actions/tool-cache';
 import * as installer from './installer';
 import * as path from 'path';
+import * as gobin from './gobin';
 
 export async function run() {
   try {
@@ -34,6 +35,10 @@ export async function run() {
         core.exportVariable('GOROOT', installDir);
         core.addPath(path.join(installDir, 'bin'));
         console.log('Added go to the path');
+
+        const gobinDir = await gobin.getGOBIN(installDir);
+        core.exportVariable('GOBIN', gobinDir);
+        core.addPath(gobinDir);
       } else {
         throw new Error(
           `Could not find a version that satisfied version spec: ${versionSpec}`


### PR DESCRIPTION
- Set GOBIN to $(go env GOPATH)/bin
- Add GOBIN to the PATH

Should make the setup of tools like golangci-lint or golint work with a
simple `go get`.

Using $GOBIN instead of $GOPATH/bin because the goal is to have GOPATH
not being directly referenced. Also, in the future, GOBIN will have a
default value too, so we would not need to manually set it, just add it
to the path (see discussion in golang/go#23439).

Closes #14.