### PR TITLE
go env block

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1322,6 +1322,10 @@ function run() {
             let goPath = yield io.which('go');
             let goVersion = (child_process_1.default.execSync(`${goPath} version`) || '').toString();
             console.log(goVersion);
+            core.startGroup('go env');
+            let goEnv = (child_process_1.default.execSync(`${goPath} env`) || '').toString();
+            console.log(goEnv);
+            core.endGroup();
         }
         catch (error) {
             core.setFailed(error.message);

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,8 +54,12 @@ export async function run() {
     // output the version actually being used
     let goPath = await io.which('go');
     let goVersion = (cp.execSync(`${goPath} version`) || '').toString();
-
     console.log(goVersion);
+
+    core.startGroup('go env');
+    let goEnv = (cp.execSync(`${goPath} env`) || '').toString();
+    console.log(goEnv);
+    core.endGroup();
   } catch (error) {
     core.setFailed(error.message);
   }


### PR DESCRIPTION
output the go env inside an expando block in the logs

<img width="795" alt="Screen Shot 2020-04-06 at 8 44 54 AM" src="https://user-images.githubusercontent.com/919564/78559788-fda53b80-77e2-11ea-9849-934a34d56937.png">
