### PR TITLE
Switch manifest installation from "master" to "main" branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ The V2 offers:
 - stable input 
 - Bug Fixes (including issues around version matching and semver)
 
+It will first check the local cache for a version match. If version is not found locally, It will pull it from `main` branch of [go-versions](https://github.com/actions/go-versions/blob/main/versions-manifest.json) repository and on miss or failure, it will fall back to the previous behavior of download directly from [go dist](https://storage.googleapis.com/golang).
+
 Matching by semver spec:
 ```yaml
 steps:

--- a/dist/index.js
+++ b/dist/index.js
@@ -5034,7 +5034,7 @@ exports.extractGoArchive = extractGoArchive;
 function getInfoFromManifest(versionSpec, stable, auth) {
     return __awaiter(this, void 0, void 0, function* () {
         let info = null;
-        const releases = yield tc.getManifestFromRepo('actions', 'go-versions', auth);
+        const releases = yield tc.getManifestFromRepo('actions', 'go-versions', auth, "main");
         core.info(`matching ${versionSpec}...`);
         const rel = yield tc.findFromManifest(versionSpec, stable, releases);
         if (rel && rel.files.length > 0) {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -140,7 +140,12 @@ export async function getInfoFromManifest(
   auth: string | undefined
 ): Promise<IGoVersionInfo | null> {
   let info: IGoVersionInfo | null = null;
-  const releases = await tc.getManifestFromRepo('actions', 'go-versions', auth);
+  const releases = await tc.getManifestFromRepo(
+    'actions',
+    'go-versions',
+    auth,
+    'main'
+  );
   core.info(`matching ${versionSpec}...`);
   const rel = await tc.findFromManifest(versionSpec, stable, releases);
 


### PR DESCRIPTION
Recently, we have switched default branch in https://github.com/actions/go-versions to `main` and we need to switch this action too.

This fix should be integrated to tag `v2.1.0`