### PR TITLE
Add `version-resolver` input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,11 @@
 name: 'Setup Go environment'
 description: 'Setup a Go environment and add it to the PATH'
 author: 'GitHub'
-inputs: 
+inputs:
   go-version:
     description: 'The Go version to download (if necessary) and use. Supports semver spec and ranges.'
+  version-resolver:
+    description: 'Version inventory for resolving semver ranges before checking tool cache. Use "manifest" for @actions/go-versions, or "dist" for golang.org/dl'
   stable:
     description: 'Whether to download only stable versions'
     default: 'true'

--- a/dist/index.js
+++ b/dist/index.js
@@ -5175,7 +5175,7 @@ function getInfoFromDist(versionSpec, stable) {
         return {
             type: 'dist',
             downloadUrl: downloadUrl,
-            resolvedVersion: version.version,
+            resolvedVersion: makeSemver(version.version),
             fileName: version.files[0].filename
         };
     });

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -219,7 +219,7 @@ async function getInfoFromDist(
   return <IGoVersionInfo>{
     type: 'dist',
     downloadUrl: downloadUrl,
-    resolvedVersion: version.version,
+    resolvedVersion: makeSemver(version.version),
     fileName: version.files[0].filename
   };
 }


### PR DESCRIPTION
Tool cache can be stale in GitHub and self-hosted runners. If supplied
`go-version` is a semver range--instead of an explicit version--it will
be tried through the version inventory in cache, first. Even though
the GitHub local copy or origin distribution may have newer versions
matching the passed range, as long as the cache can satisfy the range,
the latest version from cache will be used.

Introduce an optional input, `version-resolver`. If defined, it tries to
resolve the version spec against either GitHub local copy or Go's
canonical source of version manifest.
If the value of `version-resolver` is:
  - "manifest": the manifest file under @actions/go-version get used.
  - "dist": the manifest at https://golang.org/dl/?mode=json&include=all
  gets used.  It can take values

Example:
--------
- Latest Go Version: 1.15.2
- tool-cache has go1.15 (1.15.0), latest.

build.yml:
```
[...]
  - uses: actions/setup-go@v2
    with:
      go-version: '>=1.5 <2'
[...]
```

Although the intention of the user might be to get latest
version between "oldest Go 1.15.0, newest--not inclusive--Go 2.0", the
cache will match this range with Go 1.15.0.

build.yml (v2):
```
[...]
  - uses: actions/setup-go@v2
    with:
      go-version: '>=1.5 <2'
      version-resolver: 'manifest'
[...]
```

With supplied version resolver, the semver range will be checked against
the local GitHub version manifest from @actions/go-versions[1], and
match 1.15.2. Cache will be queried with the resolved version, instead
of the range. When the cache gets updated globally, next runs will use
the tool from the cache, instead of downloading locally or in case of
resolver 'dist', directly from Google.

[1]: https://raw.githubusercontent.com/actions/go-versions/main/versions-manifest.json

Closes #73