### PR TITLE
Add 'go-version' Output

### DIFF
--- a/__tests__/setup-go.test.ts
+++ b/__tests__/setup-go.test.ts
@@ -105,6 +105,11 @@ describe('setup-go', () => {
     jest.restoreAllMocks();
   }, 100000);
 
+  it('can extract the major.minor.patch version from a given Go version string', async () => {
+    const goVersionOutput = 'go version go1.16.6 darwin/amd64';
+    expect(main.parseGoVersion(goVersionOutput)).toBe('1.16.6');
+  });
+
   it('can find 1.9.7 from manifest on osx', async () => {
     os.platform = 'darwin';
     os.arch = 'x64';

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: 'Setup Go environment'
 description: 'Setup a Go environment and add it to the PATH'
 author: 'GitHub'
-inputs: 
+inputs:
   go-version:
     description: 'The Go version to download (if necessary) and use. Supports semver spec and ranges.'
   check-latest:
@@ -10,6 +10,9 @@ inputs:
   token:
     description: Used to pull node distributions from go-versions.  Since there's a default, this is typically not supplied by the user.
     default: ${{ github.token }}
+outputs:
+  go-version:
+    description: 'The installed Go version. Useful when given a version range as input.'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -2100,6 +2100,12 @@ function run() {
             let goPath = yield io.which('go');
             let goVersion = (child_process_1.default.execSync(`${goPath} version`) || '').toString();
             core.info(goVersion);
+            // get the installed version as an Action output
+            // based on go/src/cmd/go/internal/version/version.go:
+            // fmt.Printf("go version %s %s/%s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
+            // expecting go<version> for runtime.Version()
+            let goVersionOutput = [...goVersion.split(' ')[2]].slice(2).join('');
+            core.setOutput('go-version', goVersionOutput);
             core.startGroup('go env');
             let goEnv = (child_process_1.default.execSync(`${goPath} env`) || '').toString();
             core.info(goEnv);

--- a/dist/index.js
+++ b/dist/index.js
@@ -2058,7 +2058,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.addBinToPath = exports.run = void 0;
+exports.parseGoVersion = exports.addBinToPath = exports.run = void 0;
 const core = __importStar(__webpack_require__(470));
 const io = __importStar(__webpack_require__(1));
 const installer = __importStar(__webpack_require__(749));
@@ -2100,12 +2100,7 @@ function run() {
             let goPath = yield io.which('go');
             let goVersion = (child_process_1.default.execSync(`${goPath} version`) || '').toString();
             core.info(goVersion);
-            // get the installed version as an Action output
-            // based on go/src/cmd/go/internal/version/version.go:
-            // fmt.Printf("go version %s %s/%s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
-            // expecting go<version> for runtime.Version()
-            let goVersionOutput = [...goVersion.split(' ')[2]].slice(2).join('');
-            core.setOutput('go-version', goVersionOutput);
+            core.setOutput('go-version', parseGoVersion(goVersion));
             core.startGroup('go env');
             let goEnv = (child_process_1.default.execSync(`${goPath} env`) || '').toString();
             core.info(goEnv);
@@ -2151,6 +2146,14 @@ function isGhes() {
     const ghUrl = new url_1.URL(process.env['GITHUB_SERVER_URL'] || 'https://github.com');
     return ghUrl.hostname.toUpperCase() !== 'GITHUB.COM';
 }
+function parseGoVersion(versionString) {
+    // get the installed version as an Action output
+    // based on go/src/cmd/go/internal/version/version.go:
+    // fmt.Printf("go version %s %s/%s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
+    // expecting go<version> for runtime.Version()
+    return versionString.split(' ')[2].slice('go'.length);
+}
+exports.parseGoVersion = parseGoVersion;
 //# sourceMappingURL=main.js.map
 
 /***/ }),

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,12 +48,7 @@ export async function run() {
     let goVersion = (cp.execSync(`${goPath} version`) || '').toString();
     core.info(goVersion);
 
-    // get the installed version as an Action output
-    // based on go/src/cmd/go/internal/version/version.go:
-    // fmt.Printf("go version %s %s/%s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
-    // expecting go<version> for runtime.Version()
-    let goVersionOutput = [...goVersion.split(' ')[2]].slice(2).join('');
-    core.setOutput('go-version', goVersionOutput);
+    core.setOutput('go-version', parseGoVersion(goVersion));
 
     core.startGroup('go env');
     let goEnv = (cp.execSync(`${goPath} env`) || '').toString();
@@ -100,4 +95,12 @@ function isGhes(): boolean {
     process.env['GITHUB_SERVER_URL'] || 'https://github.com'
   );
   return ghUrl.hostname.toUpperCase() !== 'GITHUB.COM';
+}
+
+export function parseGoVersion(versionString: string): string {
+  // get the installed version as an Action output
+  // based on go/src/cmd/go/internal/version/version.go:
+  // fmt.Printf("go version %s %s/%s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
+  // expecting go<version> for runtime.Version()
+  return versionString.split(' ')[2].slice('go'.length);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,6 +48,13 @@ export async function run() {
     let goVersion = (cp.execSync(`${goPath} version`) || '').toString();
     core.info(goVersion);
 
+    // get the installed version as an Action output
+    // based on go/src/cmd/go/internal/version/version.go:
+    // fmt.Printf("go version %s %s/%s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
+    // expecting go<version> for runtime.Version()
+    let goVersionOutput = [...goVersion.split(' ')[2]].slice(2).join('');
+    core.setOutput('go-version', goVersionOutput);
+
     core.startGroup('go env');
     let goEnv = (cp.execSync(`${goPath} env`) || '').toString();
     core.info(goEnv);


### PR DESCRIPTION
This provides a `go-version` output from this Action to provide the version that was installed. This is useful if you specify only a partial version such as `1.15`, but need the full version installed such as `1.15.5` for later use in a workflow. This is similar to the same functionality in [actions/setup-python](https://github.com/actions/setup-python) -
https://github.com/actions/setup-python/blob/41b7212b1668f5de9d65e9c82aa777e6bbedb3a8/action.yml#L14-L16

## Example ##

`build.yml`:
```yaml
jobs:
  test:
    runs-on: ubuntu-latest
    steps:
      - id: setup-go
        uses: action/setup-go@v2.1.4
        with:
          go-version: '1.15'
      - name: Lookup go cache directory
        run: echo "GOCACHE_DIR=$(go env GOCACHE)" >> $GITHUB_ENV
      - uses: actions/cache@v2
        with:
          path: |
            ${{ env.GOCACHE_DIR }}
          key: "test-${{ runner.os }}-go${{ steps.setup-go.outputs.go-version }}"
```