### PR TITLE
Add GOBIN to PATH regardless of whether a version spec is specified

### DIFF
--- a/__tests__/setup-go.test.ts
+++ b/__tests__/setup-go.test.ts
@@ -441,7 +441,7 @@ describe('setup-go', () => {
       return '/Users/testuser/go';
     });
 
-    mkdirpSpy.mockImplementation(async () => { });
+    mkdirpSpy.mockImplementation(async () => {});
     existsSpy.mockImplementation(path => {
       return false;
     });
@@ -452,7 +452,7 @@ describe('setup-go', () => {
     expect(logSpy).toHaveBeenCalledWith(`Added go to the path`);
     expect(logSpy).toHaveBeenCalledWith(`Added GOBIN to the path`);
 
-    let expPath = "/Users/testuser/go/bin";
+    let expPath = '/Users/testuser/go/bin';
     expect(cnSpy).toHaveBeenCalledWith(`::add-path::${expPath}${osm.EOL}`);
   });
 
@@ -468,17 +468,19 @@ describe('setup-go', () => {
       return '/Users/testuser/go';
     });
 
-    mkdirpSpy.mockImplementation(async () => { });
+    mkdirpSpy.mockImplementation(async () => {});
     existsSpy.mockImplementation(path => {
       return false;
     });
 
     await main.run();
 
-    expect(logSpy).toHaveBeenCalledWith(`Setup go stable version spec undefined`);
+    expect(logSpy).toHaveBeenCalledWith(
+      `Setup go stable version spec undefined`
+    );
     expect(logSpy).toHaveBeenCalledWith(`Added GOBIN to the path`);
 
-    let expPath = "/Users/testuser/go/bin";
+    let expPath = '/Users/testuser/go/bin';
     expect(cnSpy).toHaveBeenCalledWith(`::add-path::${expPath}${osm.EOL}`);
   });
 

--- a/__tests__/setup-go.test.ts
+++ b/__tests__/setup-go.test.ts
@@ -427,6 +427,61 @@ describe('setup-go', () => {
     );
   });
 
+  it('adds GOBIN to PATH when go-version specified', async () => {
+    inputs['go-version'] = '1.13.0';
+
+    let toolPath = path.normalize('/cache/go/1.13.0/x64');
+    findSpy.mockImplementation(() => toolPath);
+
+    whichSpy.mockImplementation(async () => {
+      return '/usr/local/go/bin/go';
+    });
+
+    execSpy.mockImplementation(() => {
+      return '/Users/testuser/go';
+    });
+
+    mkdirpSpy.mockImplementation(async () => { });
+    existsSpy.mockImplementation(path => {
+      return false;
+    });
+
+    await main.run();
+
+    expect(logSpy).toHaveBeenCalledWith(`Setup go stable version spec 1.13.0`);
+    expect(logSpy).toHaveBeenCalledWith(`Added go to the path`);
+    expect(logSpy).toHaveBeenCalledWith(`Added GOBIN to the path`);
+
+    let expPath = "/Users/testuser/go/bin";
+    expect(cnSpy).toHaveBeenCalledWith(`::add-path::${expPath}${osm.EOL}`);
+  });
+
+  it('adds GOBIN to PATH when go-version not specified', async () => {
+    let toolPath = path.normalize('/cache/go/1.13.0/x64');
+    findSpy.mockImplementation(() => toolPath);
+
+    whichSpy.mockImplementation(async () => {
+      return '/usr/local/go/bin/go';
+    });
+
+    execSpy.mockImplementation(() => {
+      return '/Users/testuser/go';
+    });
+
+    mkdirpSpy.mockImplementation(async () => { });
+    existsSpy.mockImplementation(path => {
+      return false;
+    });
+
+    await main.run();
+
+    expect(logSpy).toHaveBeenCalledWith(`Setup go stable version spec undefined`);
+    expect(logSpy).toHaveBeenCalledWith(`Added GOBIN to the path`);
+
+    let expPath = "/Users/testuser/go/bin";
+    expect(cnSpy).toHaveBeenCalledWith(`::add-path::${expPath}${osm.EOL}`);
+  });
+
   it('does not add BIN if go is not in path', async () => {
     whichSpy.mockImplementation(async () => {
       return '';

--- a/__tests__/setup-go.test.ts
+++ b/__tests__/setup-go.test.ts
@@ -452,7 +452,7 @@ describe('setup-go', () => {
     expect(logSpy).toHaveBeenCalledWith(`Added go to the path`);
     expect(logSpy).toHaveBeenCalledWith(`Added GOBIN to the path`);
 
-    let expPath = '/Users/testuser/go/bin';
+    let expPath = path.normalize('/Users/testuser/go/bin');
     expect(cnSpy).toHaveBeenCalledWith(`::add-path::${expPath}${osm.EOL}`);
   });
 
@@ -480,7 +480,7 @@ describe('setup-go', () => {
     );
     expect(logSpy).toHaveBeenCalledWith(`Added GOBIN to the path`);
 
-    let expPath = '/Users/testuser/go/bin';
+    let expPath = path.normalize('/Users/testuser/go/bin');
     expect(cnSpy).toHaveBeenCalledWith(`::add-path::${expPath}${osm.EOL}`);
   });
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -1511,6 +1511,9 @@ function run() {
             // add gobin to path
             let added = yield addBinToPath();
             core.debug(`add bin ${added}`);
+            if (added) {
+                core.info('Added GOBIN to the path');
+            }
             // add problem matchers
             const matchersPath = path_1.default.join(__dirname, '..', 'matchers.json');
             core.info(`##[add-matcher]${matchersPath}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -1506,10 +1506,11 @@ function run() {
                 core.exportVariable('GOROOT', installDir);
                 core.addPath(path_1.default.join(installDir, 'bin'));
                 core.info('Added go to the path');
-                let added = yield addBinToPath();
-                core.debug(`add bin ${added}`);
                 core.info(`Successfully setup go version ${versionSpec}`);
             }
+            // add gobin to path
+            let added = yield addBinToPath();
+            core.debug(`add bin ${added}`);
             // add problem matchers
             const matchersPath = path_1.default.join(__dirname, '..', 'matchers.json');
             core.info(`##[add-matcher]${matchersPath}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,10 +30,12 @@ export async function run() {
       core.addPath(path.join(installDir, 'bin'));
       core.info('Added go to the path');
 
-      let added = await addBinToPath();
-      core.debug(`add bin ${added}`);
       core.info(`Successfully setup go version ${versionSpec}`);
     }
+
+    // add gobin to path
+    let added = await addBinToPath();
+    core.debug(`add bin ${added}`);
 
     // add problem matchers
     const matchersPath = path.join(__dirname, '..', 'matchers.json');

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,6 +36,9 @@ export async function run() {
     // add gobin to path
     let added = await addBinToPath();
     core.debug(`add bin ${added}`);
+    if (added) {
+      core.info('Added GOBIN to the path');
+    }
 
     // add problem matchers
     const matchersPath = path.join(__dirname, '..', 'matchers.json');


### PR DESCRIPTION
### What

Add GOBIN to PATH regardless of whether a version spec is specified.

### Why

The setup-go action adds the GOBIN to the PATH, but only if a version spec for Go is provided in the workflow configuration. When a version spec is provided the action ensures that version is installed, and then also that the GOBIN path is included in the PATH. The code that includes the GOBIN in the PATH has no dependency on the logic to install a specific version of Go and I can't see a reason why it can't run regardless. When it doesn't run, binaries that are installed in GOBIN by `go get` are not found by following steps in a workflow.

Fix #49 