### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -4,10 +4,10 @@ on:
     branches:
       - main
     paths-ignore:
-      - '**.md'
+      - "**.md"
   pull_request:
     paths-ignore:
-      - '**.md'
+      - "**.md"
 jobs:
   run:
     name: Run
@@ -16,23 +16,24 @@ jobs:
       matrix:
         operating-system: [ubuntu-latest, windows-latest]
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Setup node 12
-      uses: actions/setup-node@v1
-      with:
-        node-version: 12
+      - name: Setup node 12
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: npm
 
-    - name: npm install
-      run: npm install
+      - name: npm install
+        run: npm install
 
-    - name: Lint
-      run: npm run format-check
+      - name: Lint
+        run: npm run format-check
 
-    - name: npm test
-      run: npm test
+      - name: npm test
+        run: npm test
 
-    - name: audit packages
-      run: npm audit --audit-level=high
-      if: matrix.operating-system == 'ubuntu-latest'
+      - name: audit packages
+        run: npm audit --audit-level=high
+        if: matrix.operating-system == 'ubuntu-latest'


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
