### PR TITLE
Fix extractor selection on windows

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -5084,9 +5084,9 @@ function installGoVersion(info, auth) {
 }
 function extractGoArchive(archivePath) {
     return __awaiter(this, void 0, void 0, function* () {
-        const arch = os_1.default.arch();
+        const platform = os_1.default.platform();
         let extPath;
-        if (arch === 'win32') {
+        if (platform === 'win32') {
             extPath = yield tc.extractZip(archivePath);
         }
         else {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -122,10 +122,10 @@ async function installGoVersion(
 }
 
 export async function extractGoArchive(archivePath: string): Promise<string> {
-  const arch = os.arch();
+  const platform = os.platform();
   let extPath: string;
 
-  if (arch === 'win32') {
+  if (platform === 'win32') {
     extPath = await tc.extractZip(archivePath);
   } else {
     extPath = await tc.extractTar(archivePath);


### PR DESCRIPTION
On Windows the extractor uses `tar` instead of `zip` because the code is using `os.arch()` (which returns the arch like x64 or arm64) instead of `os.platform()`.
This PR fixes this problem.