### PR TITLE
Default version of go.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The V2 offers:
 
 It will first check the local cache for a version match. If version is not found locally, It will pull it from `main` branch of [go-versions](https://github.com/actions/go-versions/blob/main/versions-manifest.json) repository and on miss or failure, it will fall back to the previous behavior of download directly from [go dist](https://storage.googleapis.com/golang).
 
+Defaults to 1.17.2.
+
 Matching by semver spec:
 ```yaml
 steps:

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,7 @@ author: 'GitHub'
 inputs: 
   go-version:
     description: 'The Go version to download (if necessary) and use. Supports semver spec and ranges.'
+    default: '1.17.2'
   stable:
     description: 'Whether to download only stable versions'
     default: 'true'


### PR DESCRIPTION
**Description:**
Defaults to 1.17.2 the current release of go. - Obviously should be dynamic or refer to go.mod perhaps?

**Related issue:**
N/A

**Check list:**
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.