### PR TITLE
Do not export GOROOT for Go versions >= 1.9

### DIFF
--- a/__tests__/setup-go.test.ts
+++ b/__tests__/setup-go.test.ts
@@ -231,7 +231,7 @@ describe('setup-go', () => {
     expect(logSpy).toHaveBeenCalledWith(`Setup go version spec 1.13.0`);
   });
 
-  it('exports GOROOT', async () => {
+  it('does not export any varibles', async () => {
     inputs['go-version'] = '1.13.0';
     inSpy.mockImplementation(name => inputs[name]);
 
@@ -244,7 +244,7 @@ describe('setup-go', () => {
     });
 
     await main.run();
-    expect(vars).toBe({GOROOT: 'foo'});
+    expect(vars).toStrictEqual({});
   });
 
   it('finds a version of go already in the cache', async () => {

--- a/__tests__/setup-go.test.ts
+++ b/__tests__/setup-go.test.ts
@@ -240,7 +240,7 @@ describe('setup-go', () => {
     let toolPath = path.normalize('/cache/go/1.13.0/x64');
     findSpy.mockImplementation(() => toolPath);
 
-    let vars: { [key: string]: string; } = {};
+    let vars: {[key: string]: string} = {};
     exportVarSpy.mockImplementation((name: string, val: string) => {
       vars[name] = val;
     });
@@ -256,17 +256,16 @@ describe('setup-go', () => {
     let toolPath = path.normalize('/cache/go/1.8.0/x64');
     findSpy.mockImplementation(() => toolPath);
 
-    let vars: { [key: string]: string; } = {};
+    let vars: {[key: string]: string} = {};
     exportVarSpy.mockImplementation((name: string, val: string) => {
       vars[name] = val;
     });
 
     await main.run();
     expect(vars).toStrictEqual({
-      "GOROOT": toolPath
+      GOROOT: toolPath
     });
   });
-
 
   it('finds a version of go already in the cache', async () => {
     inputs['go-version'] = '1.13.0';

--- a/__tests__/setup-go.test.ts
+++ b/__tests__/setup-go.test.ts
@@ -49,6 +49,7 @@ describe('setup-go', () => {
     inSpy.mockImplementation(name => inputs[name]);
     getBooleanInputSpy = jest.spyOn(core, 'getBooleanInput');
     getBooleanInputSpy.mockImplementation(name => inputs[name]);
+    exSpy = jest.spyOn(core, 'exportVariable');
 
     // node
     os = {};
@@ -228,6 +229,22 @@ describe('setup-go', () => {
     await main.run();
 
     expect(logSpy).toHaveBeenCalledWith(`Setup go version spec 1.13.0`);
+  });
+
+  it('exports GOROOT', async () => {
+    inputs['go-version'] = '1.13.0';
+    inSpy.mockImplementation(name => inputs[name]);
+
+    let toolPath = path.normalize('/cache/go/1.13.0/x64');
+    findSpy.mockImplementation(() => toolPath);
+
+    let vars = {} as any;
+    exSpy.mockImplementation(async (name, val) => {
+      vars[name] = val;
+    });
+
+    await main.run();
+    expect(vars).toBe({GOROOT: 'foo'});
   });
 
   it('finds a version of go already in the cache', async () => {

--- a/__tests__/setup-go.test.ts
+++ b/__tests__/setup-go.test.ts
@@ -51,7 +51,6 @@ describe('setup-go', () => {
     getBooleanInputSpy = jest.spyOn(core, 'getBooleanInput');
     getBooleanInputSpy.mockImplementation(name => inputs[name]);
     exportVarSpy = jest.spyOn(core, 'exportVariable');
-    extractTarSpy = jest.spyOn(core, 'exportVariable');
 
     // node
     os = {};

--- a/dist/index.js
+++ b/dist/index.js
@@ -2086,7 +2086,7 @@ function run() {
                 const version = installer.makeSemver(versionSpec);
                 // Go versions less than 1.9 require GOROOT to be set
                 if (semver.lt(version, '1.9.0')) {
-                    core.info("Setting GOROOT for Go version < 1.9");
+                    core.info('Setting GOROOT for Go version < 1.9');
                     core.exportVariable('GOROOT', installDir);
                 }
                 let added = yield addBinToPath();

--- a/dist/index.js
+++ b/dist/index.js
@@ -2062,6 +2062,7 @@ exports.addBinToPath = exports.run = void 0;
 const core = __importStar(__webpack_require__(470));
 const io = __importStar(__webpack_require__(1));
 const installer = __importStar(__webpack_require__(749));
+const semver = __importStar(__webpack_require__(280));
 const path_1 = __importDefault(__webpack_require__(622));
 const child_process_1 = __importDefault(__webpack_require__(129));
 const fs_1 = __importDefault(__webpack_require__(747));
@@ -2082,6 +2083,12 @@ function run() {
                 const installDir = yield installer.getGo(versionSpec, checkLatest, auth);
                 core.addPath(path_1.default.join(installDir, 'bin'));
                 core.info('Added go to the path');
+                const version = installer.makeSemver(versionSpec);
+                // Go versions less than 1.9 require GOROOT to be set
+                if (semver.lt(version, '1.9.0')) {
+                    core.info("Setting GOROOT for Go version < 1.9");
+                    core.exportVariable('GOROOT', installDir);
+                }
                 let added = yield addBinToPath();
                 core.debug(`add bin ${added}`);
                 core.info(`Successfully setup go version ${versionSpec}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -2080,7 +2080,6 @@ function run() {
                 let auth = !token || isGhes() ? undefined : `token ${token}`;
                 const checkLatest = core.getBooleanInput('check-latest');
                 const installDir = yield installer.getGo(versionSpec, checkLatest, auth);
-                core.exportVariable('GOROOT', installDir);
                 core.addPath(path_1.default.join(installDir, 'bin'));
                 core.info('Added go to the path');
                 let added = yield addBinToPath();

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,7 +23,6 @@ export async function run() {
       const checkLatest = core.getBooleanInput('check-latest');
       const installDir = await installer.getGo(versionSpec, checkLatest, auth);
 
-      core.exportVariable('GOROOT', installDir);
       core.addPath(path.join(installDir, 'bin'));
       core.info('Added go to the path');
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,7 +30,7 @@ export async function run() {
       const version = installer.makeSemver(versionSpec);
       // Go versions less than 1.9 require GOROOT to be set
       if (semver.lt(version, '1.9.0')) {
-        core.info("Setting GOROOT for Go version < 1.9");
+        core.info('Setting GOROOT for Go version < 1.9');
         core.exportVariable('GOROOT', installDir);
       }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import * as core from '@actions/core';
 import * as io from '@actions/io';
 import * as installer from './installer';
+import * as semver from 'semver';
 import path from 'path';
 import cp from 'child_process';
 import fs from 'fs';
@@ -25,6 +26,13 @@ export async function run() {
 
       core.addPath(path.join(installDir, 'bin'));
       core.info('Added go to the path');
+
+      const version = installer.makeSemver(versionSpec);
+      // Go versions less than 1.9 require GOROOT to be set
+      if (semver.lt(version, '1.9.0')) {
+        core.info("Setting GOROOT for Go version < 1.9");
+        core.exportVariable('GOROOT', installDir);
+      }
 
       let added = await addBinToPath();
       core.debug(`add bin ${added}`);


### PR DESCRIPTION
**Description:**

Do not export GOROOT. This has not been necessary since [Go 1.9](https://go.dev/doc/go1.9#goroot) at least (although clunky) but definitely not since [Go 1.10](https://go.dev/doc/go1.10#goroot). This is cargo culting code that is more than 2 years out of date and runs into issues when multiple go versions are used in an action run.

**Related issue:**

#107 

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.