### PR TITLE
Update default runtime to node16

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -23,10 +23,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set Node.js 12.x
+      - name: Set Node.js 16.x
         uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 16.x
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -14,11 +14,15 @@ jobs:
     name: Check licenses
     steps:
       - uses: actions/checkout@v2
+      - name: Set Node.js 16.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
       - run: npm ci
       - name: Install licensed
         run: |
           cd $RUNNER_TEMP
-          curl -Lfs -o licensed.tar.gz https://github.com/github/licensed/releases/download/3.3.1/licensed-3.3.1-linux-x64.tar.gz
+          curl -Lfs -o licensed.tar.gz https://github.com/github/licensed/releases/download/3.4.4/licensed-3.4.4-linux-x64.tar.gz
           sudo tar -xzf licensed.tar.gz
           sudo mv licensed /usr/local/bin/licensed
       - run: licensed status

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -78,7 +78,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        go: [1.7, 1.8.6]
+        go: [1.9, 1.8.6]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,10 +19,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup node 12
+      - name: Setup node 16
         uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
           cache: npm
 
       - name: npm ci

--- a/action.yml
+++ b/action.yml
@@ -14,5 +14,5 @@ inputs:
     description: Used to pull node distributions from go-versions.  Since there's a default, this is typically not supplied by the user.
     default: ${{ github.token }}
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Node 12 has an end of life on April 30, 2022.

This PR updates the default runtime to [node16](https://github.blog/changelog/2021-12-10-github-actions-github-hosted-runners-now-run-node-js-16-by-default/), rather then node12. 

This is supported on all Actions Runners v2.285.0 or later.

**Description:**
Describe your changes.

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.