### PR TITLE
Bump GitHub actions, `README.md` cleanups

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -44,7 +44,7 @@ jobs:
         id: diff
 
       # If index.js was different than expected, upload the expected version as an artifact
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ failure() && steps.diff.conclusion == 'failure' }}
         with:
           name: dist

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set Node.js 16.x
         uses: actions/setup-node@v2

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set Node.js 16.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
 

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set Node.js 16.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
       - run: npm ci

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Check licenses
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set Node.js 16.x
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -22,7 +22,7 @@ jobs:
         go: [1.12, 1.13, 1.14]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: setup-go ${{ matrix.go }}
         uses: ./
@@ -41,7 +41,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         go-version: [1.16, 1.17]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Go and check latest
         uses: ./
         with:
@@ -60,13 +60,13 @@ jobs:
         go: [1.12.16, 1.13.11, 1.14.3]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      
+        uses: actions/checkout@v3
+
       - name: setup-go ${{ matrix.go }}
         uses: ./
         with:
           go-version: ${{ matrix.go }}
-      
+
       - name: verify go
         run: __tests__/verify-go.sh ${{ matrix.go }}
         shell: bash
@@ -81,7 +81,7 @@ jobs:
         go: [1.9, 1.8.6]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: setup-go ${{ matrix.go }}
         uses: ./

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -17,7 +17,7 @@ jobs:
         operating-system: [ubuntu-latest, windows-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup node 16
         uses: actions/setup-node@v2

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup node 16
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: npm

--- a/README.md
+++ b/README.md
@@ -8,22 +8,22 @@
 
 This action sets up a go environment for use in actions by:
 
-- optionally downloading and caching a version of Go by version and adding to PATH
-- registering problem matchers for error output
+- Optionally downloading and caching a version of Go by version and adding to `PATH`.
+- Registering problem matchers for error output.
 
 # V3
 
 The V3 edition of the action offers:
 
 - Adds `GOBIN` to the `PATH`
-- Proxy Support
-- `stable` input
+- Proxy support
 - Check latest version
-- Bug Fixes (including issues around version matching and semver)
+- Bug fixes (including issues around version matching and semver)
 
 The action will first check the local cache for a version match. If a version is not found locally, it will pull it from the `main` branch of the [go-versions](https://github.com/actions/go-versions/blob/main/versions-manifest.json) repository. On miss or failure, it will fall back to downloading directly from [go dist](https://storage.googleapis.com/golang). To change the default behavior, please use the [check-latest input](#check-latest-version).
 
 Matching by [semver spec](https://github.com/npm/node-semver):
+
 ```yaml
 steps:
   - uses: actions/checkout@v3
@@ -66,6 +66,7 @@ steps:
 See [action.yml](action.yml)
 
 ## Basic:
+
 ```yaml
 steps:
   - uses: actions/checkout@v3
@@ -95,6 +96,7 @@ steps:
 ```
 
 ## Matrix Testing:
+
 ```yaml
 jobs:
   build:
@@ -113,6 +115,7 @@ jobs:
 ```
 
 ### Supported version syntax
+
 The `go-version` input supports the following syntax:
 
 Specific versions: `1.15`, `1.16.1`, `1.17.0-rc.2`, `1.16.0-beta.1`

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p align="left">
   <a href="https://github.com/actions/setup-go/actions"><img alt="GitHub Actions status" src="https://github.com/actions/setup-go/workflows/build-test/badge.svg"></a>
 
-  <a href="https://github.com/actions/setup-go/actions"><img alt="versions status" src="https://github.com/actions/setup-go/workflows/go-versions/badge.svg"></a>  
+  <a href="https://github.com/actions/setup-go/actions"><img alt="versions status" src="https://github.com/actions/setup-go/workflows/go-versions/badge.svg"></a>
 </p>
 
 This action sets up a go environment for use in actions by:
@@ -16,6 +16,7 @@ This action sets up a go environment for use in actions by:
 The V3 offers:
 - Adds GOBIN to the PATH
 - Proxy Support
+- `stable` input
 - Check latest version
 - Bug Fixes (including issues around version matching and semver)
 
@@ -25,7 +26,7 @@ Matching by [semver spec](https://github.com/npm/node-semver):
 ```yaml
 steps:
   - uses: actions/checkout@v3
-  - uses: actions/setup-go@v3
+  - uses: actions/setup-go@v2
     with:
       go-version: '^1.13.1' # The Go version to download (if necessary) and use.
   - run: go version
@@ -44,7 +45,7 @@ Matching an unstable pre-release:
 ```yaml
 steps:
   - uses: actions/checkout@v3
-  - uses: actions/setup-go@v3
+  - uses: actions/setup-go@v2
     with:
       go-version: '1.18.0-rc.1' # The Go version to download (if necessary) and use.
   - run: go version
@@ -67,14 +68,14 @@ See [action.yml](action.yml)
 ```yaml
 steps:
   - uses: actions/checkout@v3
-  - uses: actions/setup-go@v3
+  - uses: actions/setup-go@v2
     with:
       go-version: '1.16.1' # The Go version to download (if necessary) and use.
   - run: go run hello.go
 ```
 
 
-## Check latest version:  
+## Check latest version:
 
 The `check-latest` flag defaults to `false`. Use the default or set `check-latest` to `false` if you prefer stability and if you want to ensure a specific Go version is always used.
 
@@ -85,7 +86,7 @@ If `check-latest` is set to `true`, the action first checks if the cached versio
 ```yaml
 steps:
   - uses: actions/checkout@v3
-  - uses: actions/setup-go@v3
+  - uses: actions/setup-go@v2
     with:
       go-version: '1.14'
       check-latest: true
@@ -113,7 +114,7 @@ jobs:
 ### Supported version syntax
 The `go-version` input supports the following syntax:
 
-Specific versions: `1.15`, `1.16.1`, `1.17.0-rc.2`, `1.16.0-beta.1`  
+Specific versions: `1.15`, `1.16.1`, `1.17.0-rc.2`, `1.16.0-beta.1`
 SemVer's version range syntax: `^1.13.1`, `>=1.18.0-rc.1`
 For more information about semantic versioning please refer [semver](https://github.com/npm/node-semver) documentation
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 # setup-go
 
-<p align="left">
-  <a href="https://github.com/actions/setup-go/actions"><img alt="GitHub Actions status" src="https://github.com/actions/setup-go/workflows/build-test/badge.svg"></a>
-
-  <a href="https://github.com/actions/setup-go/actions"><img alt="versions status" src="https://github.com/actions/setup-go/workflows/go-versions/badge.svg"></a>
-</p>
+[![build-test](https://github.com/actions/setup-go/actions/workflows/workflow.yml/badge.svg)](https://github.com/actions/setup-go/actions/workflows/workflow.yml)
+[![Validate 'setup-go'](https://github.com/actions/setup-go/actions/workflows/versions.yml/badge.svg)](https://github.com/actions/setup-go/actions/workflows/versions.yml)
 
 This action sets up a go environment for use in actions by:
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ This action sets up a go environment for use in actions by:
 
 # V3
 
-The V3 offers:
-- Adds GOBIN to the PATH
+The V3 edition of the action offers:
+
+- Adds `GOBIN` to the `PATH`
 - Proxy Support
 - `stable` input
 - Check latest version
@@ -26,7 +27,7 @@ Matching by [semver spec](https://github.com/npm/node-semver):
 ```yaml
 steps:
   - uses: actions/checkout@v3
-  - uses: actions/setup-go@v2
+  - uses: actions/setup-go@v3
     with:
       go-version: '^1.13.1' # The Go version to download (if necessary) and use.
   - run: go version
@@ -45,7 +46,7 @@ Matching an unstable pre-release:
 ```yaml
 steps:
   - uses: actions/checkout@v3
-  - uses: actions/setup-go@v2
+  - uses: actions/setup-go@v3
     with:
       go-version: '1.18.0-rc.1' # The Go version to download (if necessary) and use.
   - run: go version
@@ -68,7 +69,7 @@ See [action.yml](action.yml)
 ```yaml
 steps:
   - uses: actions/checkout@v3
-  - uses: actions/setup-go@v2
+  - uses: actions/setup-go@v3
     with:
       go-version: '1.16.1' # The Go version to download (if necessary) and use.
   - run: go run hello.go
@@ -86,7 +87,7 @@ If `check-latest` is set to `true`, the action first checks if the cached versio
 ```yaml
 steps:
   - uses: actions/checkout@v3
-  - uses: actions/setup-go@v2
+  - uses: actions/setup-go@v3
     with:
       go-version: '1.14'
       check-latest: true


### PR DESCRIPTION
**Description:**
- Bump some GitHub Actions
  - `actions/checkout@v3`
  - `actions/setup-node@v3`
  - `actions/upload-artifact@v3`
  - `actions/setup-go@v3` (in self examples in `README.md`)
- Removed reference to `stable` action argument - removed in #195
  - **Note:** seems this has already been done.
- Added "new style" workflow build badges - generated by the GitHub web UI.

**Related issue:**
N/A

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.