### PR TITLE
await io.mkdirP

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2127,12 +2127,12 @@ function addBinToPath() {
             if (!fs_1.default.existsSync(gp)) {
                 // some of the hosted images have go install but not profile dir
                 core.debug(`creating ${gp}`);
-                io.mkdirP(gp);
+                yield io.mkdirP(gp);
             }
             let bp = path_1.default.join(gp, 'bin');
             if (!fs_1.default.existsSync(bp)) {
                 core.debug(`creating ${bp}`);
-                io.mkdirP(bp);
+                yield io.mkdirP(bp);
             }
             core.addPath(bp);
             added = true;

--- a/src/main.ts
+++ b/src/main.ts
@@ -73,13 +73,13 @@ export async function addBinToPath(): Promise<boolean> {
     if (!fs.existsSync(gp)) {
       // some of the hosted images have go install but not profile dir
       core.debug(`creating ${gp}`);
-      io.mkdirP(gp);
+      await io.mkdirP(gp);
     }
 
     let bp = path.join(gp, 'bin');
     if (!fs.existsSync(bp)) {
       core.debug(`creating ${bp}`);
-      io.mkdirP(bp);
+      await io.mkdirP(bp);
     }
 
     core.addPath(bp);


### PR DESCRIPTION
**Description:**
io.mkdirP returns a promise that should be awaited. Without this the promise runs in the background and `addBinToPath` returns OK but then the promise errors later on.

**Related issue:**
https://github.com/actions/setup-go/issues/169

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.