### PR TITLE
Fix condition for GOPATH output

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2122,7 +2122,7 @@ function addBinToPath() {
             return added;
         }
         let buf = child_process_1.default.execSync('go env GOPATH');
-        if (buf) {
+        if (buf.length > 1) {
             let gp = buf.toString().trim();
             core.debug(`go env GOPATH :${gp}:`);
             if (!fs_1.default.existsSync(gp)) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,7 +69,7 @@ export async function addBinToPath(): Promise<boolean> {
   }
 
   let buf = cp.execSync('go env GOPATH');
-  if (buf) {
+  if (buf.length > 1) {
     let gp = buf.toString().trim();
     core.debug(`go env GOPATH :${gp}:`);
     if (!fs.existsSync(gp)) {


### PR DESCRIPTION
**Description:**
At the moment `setup-go` action has logic to create directory and add it in the runner PATH if the `go env GOPATH` command has path in output. There is no path in command output for go version < 1.7 but this command returns single byte so the condition to check `go env GOPATH` output is true for any go versions.
For example
go 1.5:

<img width="638" alt="Screenshot 2022-04-17 at 5 55 06 PM" src="https://user-images.githubusercontent.com/7628945/163722339-208b0aa1-a704-4a1d-8c10-90171cba6115.png">

go 1.18:

<img width="584" alt="Screenshot 2022-04-17 at 5 57 51 PM" src="https://user-images.githubusercontent.com/7628945/163722497-f670bf62-d4f7-468a-b635-890b0674bece.png">

This logic caused an error but it did not interrupt action on node 12 (action v2 version):

<img width="929" alt="Screenshot 2022-04-17 at 6 06 48 PM" src="https://user-images.githubusercontent.com/7628945/163722825-dd4716fc-c292-4a1c-8752-8420cf242484.png">

Successful run with error for go 1.5 on action v2 version: https://github.com/vsafonkin/test-repo/runs/6054892779?check_suite_focus=true#logs

After action update to node 16 (action v3 version) this error breaks the action execution.

Fixed the condition for `go env PATH` output.
Test run with go 1.18: https://github.com/vsafonkin/test-repo/actions/runs/2180363887
Test run with go 1.5: https://github.com/vsafonkin/test-repo/actions/runs/2180366207

**Related issue:**
#216 

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.