### PR TITLE
Use explicit filename when downloading Windows go package

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -62942,7 +62942,11 @@ function resolveVersionFromManifest(versionSpec, stable, auth) {
 function installGoVersion(info, auth) {
     return __awaiter(this, void 0, void 0, function* () {
         core.info(`Acquiring ${info.resolvedVersion} from ${info.downloadUrl}`);
-        const downloadPath = yield tc.downloadTool(info.downloadUrl, undefined, auth);
+        // Windows requires that we keep the extension (.zip) for extraction
+        const isWindows = os_1.default.platform() === 'win32';
+        const tempDir = process.env.RUNNER_TEMP || '.';
+        const fileName = isWindows ? path.join(tempDir, info.fileName) : undefined;
+        const downloadPath = yield tc.downloadTool(info.downloadUrl, fileName, auth);
         core.info('Extracting Go...');
         let extPath = yield extractGoArchive(downloadPath);
         core.info(`Successfully extracted go to ${extPath}`);

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -132,7 +132,13 @@ async function installGoVersion(
   auth: string | undefined
 ): Promise<string> {
   core.info(`Acquiring ${info.resolvedVersion} from ${info.downloadUrl}`);
-  const downloadPath = await tc.downloadTool(info.downloadUrl, undefined, auth);
+
+  // Windows requires that we keep the extension (.zip) for extraction
+  const isWindows = os.platform() === 'win32';
+  const tempDir = process.env.RUNNER_TEMP || '.';
+  const fileName = isWindows ? path.join(tempDir, info.fileName) : undefined;
+
+  const downloadPath = await tc.downloadTool(info.downloadUrl, fileName, auth);
 
   core.info('Extracting Go...');
   let extPath = await extractGoArchive(downloadPath);


### PR DESCRIPTION
**Description:**
Use explicit filename when downloading Windows go package.

Using the explicit filename for Windows is necessary to satisfy `Expand-Archive`'s requirement on `.zip` extension.

The solution can be seen working [here](https://github.com/buildpacks/pack/runs/7570679322?check_suite_focus=true) ([screenshot](https://user-images.githubusercontent.com/475559/181657378-24702fd4-d567-4c36-83b3-e1e6e59b0899.png)).


---

Credit goes to @redanthrax for finding the root cause. 

This PR differs from https://github.com/actions/setup-go/pull/242 in the following ways:

1. When available, uses `RUNNER_TEMP` env var similar to [tool-cache](https://github.com/actions/toolkit/blob/01e1ff7bc04e1c57c980a0d1530478a5b60cf812/packages/tool-cache/src/tool-cache.ts#L755-L759).
2. Added tests for the implemented scenario.
3. It **DOES NOT** update `tool-cache` library (to minimize changes).

---

**Related issue:**

Fixes #241

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.