### PR TITLE
refactor: Use early return pattern to avoid nested conditions

### DIFF
--- a/__tests__/cache-utils.test.ts
+++ b/__tests__/cache-utils.test.ts
@@ -162,7 +162,7 @@ describe('isCacheFeatureAvailable', () => {
     expect(functionResult).toBeFalsy();
   });
 
-  it('should throw when cache feature is unavailable and GHES is used', () => {
+  it('should warn when cache feature is unavailable and GHES is used', () => {
     //Arrange
     isFeatureAvailableSpy.mockImplementation(() => {
       return false;
@@ -170,10 +170,11 @@ describe('isCacheFeatureAvailable', () => {
 
     process.env['GITHUB_SERVER_URL'] = 'https://nongithub.com';
 
-    let errorMessage =
+    let warningMessage =
       'Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.';
 
     //Act + Assert
-    expect(() => cacheUtils.isCacheFeatureAvailable()).toThrow(errorMessage);
+    expect(cacheUtils.isCacheFeatureAvailable()).toBeFalsy();
+    expect(warningSpy).toHaveBeenCalledWith(warningMessage);
   });
 });

--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -60471,16 +60471,14 @@ function isGhes() {
 }
 exports.isGhes = isGhes;
 function isCacheFeatureAvailable() {
-    if (!cache.isFeatureAvailable()) {
-        if (isGhes()) {
-            throw new Error('Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.');
-        }
-        else {
-            core.warning('The runner was not able to contact the cache service. Caching will be skipped');
-        }
-        return false;
+    if (cache.isFeatureAvailable()) {
+        return true;
     }
-    return true;
+    if (isGhes()) {
+        throw new Error('Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.');
+    }
+    core.warning('The runner was not able to contact the cache service. Caching will be skipped');
+    return false;
 }
 exports.isCacheFeatureAvailable = isCacheFeatureAvailable;
 

--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -60475,7 +60475,8 @@ function isCacheFeatureAvailable() {
         return true;
     }
     if (isGhes()) {
-        throw new Error('Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.');
+        core.warning('Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.');
+        return false;
     }
     core.warning('The runner was not able to contact the cache service. Caching will be skipped');
     return false;

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -63144,16 +63144,14 @@ function isGhes() {
 }
 exports.isGhes = isGhes;
 function isCacheFeatureAvailable() {
-    if (!cache.isFeatureAvailable()) {
-        if (isGhes()) {
-            throw new Error('Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.');
-        }
-        else {
-            core.warning('The runner was not able to contact the cache service. Caching will be skipped');
-        }
-        return false;
+    if (cache.isFeatureAvailable()) {
+        return true;
     }
-    return true;
+    if (isGhes()) {
+        throw new Error('Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.');
+    }
+    core.warning('The runner was not able to contact the cache service. Caching will be skipped');
+    return false;
 }
 exports.isCacheFeatureAvailable = isCacheFeatureAvailable;
 

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -63148,7 +63148,8 @@ function isCacheFeatureAvailable() {
         return true;
     }
     if (isGhes()) {
-        throw new Error('Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.');
+        core.warning('Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.');
+        return false;
     }
     core.warning('The runner was not able to contact the cache service. Caching will be skipped');
     return false;

--- a/src/cache-utils.ts
+++ b/src/cache-utils.ts
@@ -62,9 +62,10 @@ export function isCacheFeatureAvailable(): boolean {
   }
 
   if (isGhes()) {
-    throw new Error(
+    core.warning(
       'Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.'
     );
+    return false;
   }
 
   core.warning(

--- a/src/cache-utils.ts
+++ b/src/cache-utils.ts
@@ -57,19 +57,18 @@ export function isGhes(): boolean {
 }
 
 export function isCacheFeatureAvailable(): boolean {
-  if (!cache.isFeatureAvailable()) {
-    if (isGhes()) {
-      throw new Error(
-        'Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.'
-      );
-    } else {
-      core.warning(
-        'The runner was not able to contact the cache service. Caching will be skipped'
-      );
-    }
-
-    return false;
+  if (cache.isFeatureAvailable()) {
+    return true;
   }
 
-  return true;
+  if (isGhes()) {
+    throw new Error(
+      'Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.'
+    );
+  }
+
+  core.warning(
+    'The runner was not able to contact the cache service. Caching will be skipped'
+  );
+  return false;
 }


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>
Issue #297 

## Description

Return early is the way of writing functions or methods so that the expected positive result is returned at the end of the function and the rest of the code terminates the execution (by returning or throwing an exception) when conditions are not met.

See [actions/cache#1012](https://github.com/actions/cache/issues/1012), [actions/setup-node#639](https://github.com/actions/setup-node/pull/639)

In `cache-utils.ts`:

**AS-IS**

```typescript
export function isCacheFeatureAvailable(): boolean {
  if (!cache.isFeatureAvailable()) {
    if (isGhes()) {
      throw new Error(
        'Cache action is only supported on GHES version >= 3.5...'
      );
    } else {
      core.warning(
        'The runner was not able to contact...'
      );
    }

    return false;
  }

  return true;
}
```


**TO-BE**

```typescript
export function isCacheFeatureAvailable(): boolean {
  if (cache.isFeatureAvailable()) {
    return true;
  }

  if (isGhes()) {
    throw new Error(
      'Cache action is only supported on GHES version >= 3.5...'
    );
  }

  core.warning(
    'The runner was not able to contact...'
  );
  return false;
}
```

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.