### PR TITLE
Allow to use only GOCACHE for cache

### DIFF
--- a/__tests__/cache-utils.test.ts
+++ b/__tests__/cache-utils.test.ts
@@ -93,6 +93,41 @@ describe('getCacheDirectoryPath', () => {
       .then(data => expect(data).toEqual(expectedResult));
   });
 
+  it('should return path to the cache folder if one command return empty str', async () => {
+    //Arrange
+    getExecOutputSpy.mockImplementationOnce((commandLine: string) => {
+      return new Promise<exec.ExecOutput>(resolve => {
+        resolve({exitCode: 0, stdout: 'path/to/cache/folder', stderr: ''});
+      });
+    });
+
+    getExecOutputSpy.mockImplementationOnce((commandLine: string) => {
+      return new Promise<exec.ExecOutput>(resolve => {
+        resolve({exitCode: 0, stdout: '', stderr: ''});
+      });
+    });
+
+    const expectedResult = ['path/to/cache/folder'];
+
+    //Act + Assert
+    return cacheUtils
+      .getCacheDirectoryPath(validPackageManager)
+      .then(data => expect(data).toEqual(expectedResult));
+  });
+
+  it('should throw if the both commands return empty str', async () => {
+    getExecOutputSpy.mockImplementation((commandLine: string) => {
+      return new Promise<exec.ExecOutput>(resolve => {
+        resolve({exitCode: 10, stdout: '', stderr: ''});
+      });
+    });
+
+    //Act + Assert
+    expect(async () => {
+      await cacheUtils.getCacheDirectoryPath(validPackageManager);
+    }).rejects.toThrow();
+  });
+
   it('should throw if the specified package name is invalid', async () => {
     getExecOutputSpy.mockImplementation((commandLine: string) => {
       return new Promise<exec.ExecOutput>(resolve => {

--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -60457,12 +60457,12 @@ const getPackageManagerInfo = (packageManager) => __awaiter(void 0, void 0, void
 });
 exports.getPackageManagerInfo = getPackageManagerInfo;
 const getCacheDirectoryPath = (packageManagerInfo) => __awaiter(void 0, void 0, void 0, function* () {
-    let pathList = yield Promise.all(packageManagerInfo.cacheFolderCommandList.map(command => exports.getCommandOutput(command)));
-    const emptyPaths = pathList.filter(item => !item);
-    if (emptyPaths.length) {
+    const pathList = yield Promise.all(packageManagerInfo.cacheFolderCommandList.map(command => exports.getCommandOutput(command)));
+    const cachePaths = pathList.filter(item => item);
+    if (!cachePaths.length) {
         throw new Error(`Could not get cache folder paths.`);
     }
-    return pathList;
+    return cachePaths;
 });
 exports.getCacheDirectoryPath = getCacheDirectoryPath;
 function isGhes() {

--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -60457,12 +60457,12 @@ const getPackageManagerInfo = (packageManager) => __awaiter(void 0, void 0, void
 });
 exports.getPackageManagerInfo = getPackageManagerInfo;
 const getCacheDirectoryPath = (packageManagerInfo) => __awaiter(void 0, void 0, void 0, function* () {
-    let pathList = yield Promise.all(packageManagerInfo.cacheFolderCommandList.map(command => exports.getCommandOutput(command)));
-    const emptyPaths = pathList.filter(item => !item);
-    if (emptyPaths.length) {
+    const pathList = yield Promise.all(packageManagerInfo.cacheFolderCommandList.map(command => exports.getCommandOutput(command)));
+    const notEmptyPaths = pathList.filter(item => item);
+    if (!notEmptyPaths.length) {
         throw new Error(`Could not get cache folder paths.`);
     }
-    return pathList;
+    return notEmptyPaths;
 });
 exports.getCacheDirectoryPath = getCacheDirectoryPath;
 function isGhes() {

--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -60458,11 +60458,11 @@ const getPackageManagerInfo = (packageManager) => __awaiter(void 0, void 0, void
 exports.getPackageManagerInfo = getPackageManagerInfo;
 const getCacheDirectoryPath = (packageManagerInfo) => __awaiter(void 0, void 0, void 0, function* () {
     const pathList = yield Promise.all(packageManagerInfo.cacheFolderCommandList.map(command => exports.getCommandOutput(command)));
-    const notEmptyPaths = pathList.filter(item => item);
-    if (!notEmptyPaths.length) {
+    const cachePaths = pathList.filter(item => item);
+    if (!cachePaths.length) {
         throw new Error(`Could not get cache folder paths.`);
     }
-    return notEmptyPaths;
+    return cachePaths;
 });
 exports.getCacheDirectoryPath = getCacheDirectoryPath;
 function isGhes() {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -63131,11 +63131,11 @@ const getPackageManagerInfo = (packageManager) => __awaiter(void 0, void 0, void
 exports.getPackageManagerInfo = getPackageManagerInfo;
 const getCacheDirectoryPath = (packageManagerInfo) => __awaiter(void 0, void 0, void 0, function* () {
     const pathList = yield Promise.all(packageManagerInfo.cacheFolderCommandList.map(command => exports.getCommandOutput(command)));
-    const notEmptyPaths = pathList.filter(item => item);
-    if (!notEmptyPaths.length) {
+    const cachePaths = pathList.filter(item => item);
+    if (!cachePaths.length) {
         throw new Error(`Could not get cache folder paths.`);
     }
-    return notEmptyPaths;
+    return cachePaths;
 });
 exports.getCacheDirectoryPath = getCacheDirectoryPath;
 function isGhes() {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -63130,12 +63130,12 @@ const getPackageManagerInfo = (packageManager) => __awaiter(void 0, void 0, void
 });
 exports.getPackageManagerInfo = getPackageManagerInfo;
 const getCacheDirectoryPath = (packageManagerInfo) => __awaiter(void 0, void 0, void 0, function* () {
-    let pathList = yield Promise.all(packageManagerInfo.cacheFolderCommandList.map(command => exports.getCommandOutput(command)));
-    const emptyPaths = pathList.filter(item => !item);
-    if (emptyPaths.length) {
+    const pathList = yield Promise.all(packageManagerInfo.cacheFolderCommandList.map(command => exports.getCommandOutput(command)));
+    const notEmptyPaths = pathList.filter(item => item);
+    if (!notEmptyPaths.length) {
         throw new Error(`Could not get cache folder paths.`);
     }
-    return pathList;
+    return notEmptyPaths;
 });
 exports.getCacheDirectoryPath = getCacheDirectoryPath;
 function isGhes() {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -63130,12 +63130,12 @@ const getPackageManagerInfo = (packageManager) => __awaiter(void 0, void 0, void
 });
 exports.getPackageManagerInfo = getPackageManagerInfo;
 const getCacheDirectoryPath = (packageManagerInfo) => __awaiter(void 0, void 0, void 0, function* () {
-    let pathList = yield Promise.all(packageManagerInfo.cacheFolderCommandList.map(command => exports.getCommandOutput(command)));
-    const emptyPaths = pathList.filter(item => !item);
-    if (emptyPaths.length) {
+    const pathList = yield Promise.all(packageManagerInfo.cacheFolderCommandList.map(command => exports.getCommandOutput(command)));
+    const cachePaths = pathList.filter(item => item);
+    if (!cachePaths.length) {
         throw new Error(`Could not get cache folder paths.`);
     }
-    return pathList;
+    return cachePaths;
 });
 exports.getCacheDirectoryPath = getCacheDirectoryPath;
 function isGhes() {

--- a/src/cache-utils.ts
+++ b/src/cache-utils.ts
@@ -40,13 +40,13 @@ export const getCacheDirectoryPath = async (
     )
   );
 
-  const cachePaths  = pathList.filter(item => item);
+  const cachePaths = pathList.filter(item => item);
 
   if (!cachePaths.length) {
     throw new Error(`Could not get cache folder paths.`);
   }
 
-  return cachePaths ;
+  return cachePaths;
 };
 
 export function isGhes(): boolean {

--- a/src/cache-utils.ts
+++ b/src/cache-utils.ts
@@ -34,19 +34,19 @@ export const getPackageManagerInfo = async (packageManager: string) => {
 export const getCacheDirectoryPath = async (
   packageManagerInfo: PackageManagerInfo
 ) => {
-  let pathList = await Promise.all(
+  const pathList = await Promise.all(
     packageManagerInfo.cacheFolderCommandList.map(command =>
       getCommandOutput(command)
     )
   );
 
-  const emptyPaths = pathList.filter(item => !item);
+  const notEmptyPaths = pathList.filter(item => item);
 
-  if (emptyPaths.length) {
+  if (!notEmptyPaths.length) {
     throw new Error(`Could not get cache folder paths.`);
   }
 
-  return pathList;
+  return notEmptyPaths;
 };
 
 export function isGhes(): boolean {

--- a/src/cache-utils.ts
+++ b/src/cache-utils.ts
@@ -40,13 +40,13 @@ export const getCacheDirectoryPath = async (
     )
   );
 
-  const notEmptyPaths = pathList.filter(item => item);
+  const cachePaths  = pathList.filter(item => item);
 
-  if (!notEmptyPaths.length) {
+  if (!cachePaths.length) {
     throw new Error(`Could not get cache folder paths.`);
   }
 
-  return notEmptyPaths;
+  return cachePaths ;
 };
 
 export function isGhes(): boolean {


### PR DESCRIPTION
**Description:**
Since older versions of go (before 1.15) do not have the `GOMODCACHE` command, we must allow the cache to be built only based on the output of the `GOCACHE` command

**Related issue:**
https://github.com/actions/setup-go/issues/304

**Check list:**
- [ ] Mark if documentation changes are required.
- [+] Mark if tests were added or updated to cover the changes.