### PR TITLE
define download-base-url to replace https://github.com to use another…

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,9 @@ inputs:
   token:
     description: Used to pull node distributions from go-versions. Since there's a default, this is typically not supplied by the user. When running this action on github.com, the default value is sufficient. When running on GHES, you can pass a personal access token for github.com if you are experiencing rate limiting.
     default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
+  download-base-url:
+    description: 'The download base url to use instead of the https://github.com'
+    required: false
   cache:
     description: Used to specify whether caching is needed. Set to true, if you'd like to enable caching.
     default: false
@@ -19,6 +22,7 @@ inputs:
     description: 'Used to specify the path to a dependency file - go.sum'
   architecture:
     description: 'Target architecture for Go to use. Examples: x86, x64. Will use system architecture by default.'
+
 outputs:
   go-version:
     description: 'The installed Go version. Useful when given a version range as input.'

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -63226,7 +63226,7 @@ const sys = __importStar(__nccwpck_require__(4300));
 const fs_1 = __importDefault(__nccwpck_require__(7147));
 const os_1 = __importDefault(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(1314);
-function getGo(versionSpec, checkLatest, auth, arch = os_1.default.arch()) {
+function getGo(versionSpec, checkLatest, auth, arch = os_1.default.arch(), downloadBaseUrl) {
     return __awaiter(this, void 0, void 0, function* () {
         let manifest;
         let osPlat = os_1.default.platform();
@@ -63245,7 +63245,7 @@ function getGo(versionSpec, checkLatest, auth, arch = os_1.default.arch()) {
         }
         if (checkLatest) {
             core.info('Attempting to resolve the latest version from the manifest...');
-            const resolvedVersion = yield resolveVersionFromManifest(versionSpec, true, auth, arch, manifest);
+            const resolvedVersion = yield resolveVersionFromManifest(versionSpec, true, auth, arch, manifest, downloadBaseUrl);
             if (resolvedVersion) {
                 versionSpec = resolvedVersion;
                 core.info(`Resolved as '${versionSpec}'`);
@@ -63308,10 +63308,10 @@ function getGo(versionSpec, checkLatest, auth, arch = os_1.default.arch()) {
     });
 }
 exports.getGo = getGo;
-function resolveVersionFromManifest(versionSpec, stable, auth, arch, manifest) {
+function resolveVersionFromManifest(versionSpec, stable, auth, arch, manifest, downloadBaseUrl) {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            const info = yield getInfoFromManifest(versionSpec, stable, auth, arch, manifest);
+            const info = yield getInfoFromManifest(versionSpec, stable, auth, arch, manifest, downloadBaseUrl);
             return info === null || info === void 0 ? void 0 : info.resolvedVersion;
         }
         catch (err) {
@@ -63360,7 +63360,7 @@ function getManifest(auth) {
     });
 }
 exports.getManifest = getManifest;
-function getInfoFromManifest(versionSpec, stable, auth, arch = os_1.default.arch(), manifest) {
+function getInfoFromManifest(versionSpec, stable, auth, arch = os_1.default.arch(), manifest, downloadBaseUrl) {
     return __awaiter(this, void 0, void 0, function* () {
         let info = null;
         if (!manifest) {
@@ -63374,6 +63374,9 @@ function getInfoFromManifest(versionSpec, stable, auth, arch = os_1.default.arch
             info.type = 'manifest';
             info.resolvedVersion = rel.version;
             info.downloadUrl = rel.files[0].download_url;
+            if (downloadBaseUrl) {
+                info.downloadUrl = info.downloadUrl.replace('https://github.com', downloadBaseUrl);
+            }
             info.fileName = rel.files[0].filename;
         }
         return info;
@@ -63581,6 +63584,7 @@ function run() {
             const cache = core.getBooleanInput('cache');
             core.info(`Setup go version spec ${versionSpec}`);
             let arch = core.getInput('architecture');
+            let downloadBaseUrl = core.getInput('download-base-url');
             if (!arch) {
                 arch = os_1.default.arch();
             }
@@ -63588,7 +63592,7 @@ function run() {
                 let token = core.getInput('token');
                 let auth = !token ? undefined : `token ${token}`;
                 const checkLatest = core.getBooleanInput('check-latest');
-                const installDir = yield installer.getGo(versionSpec, checkLatest, auth, arch);
+                const installDir = yield installer.getGo(versionSpec, checkLatest, auth, arch, downloadBaseUrl);
                 const installDirVersion = path_1.default.basename(path_1.default.dirname(installDir));
                 core.addPath(path_1.default.join(installDir, 'bin'));
                 core.info('Added go to the path');

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -34,7 +34,8 @@ export async function getGo(
   versionSpec: string,
   checkLatest: boolean,
   auth: string | undefined,
-  arch = os.arch()
+  arch = os.arch(),
+  downloadBaseUrl?: string | undefined
 ) {
   let manifest: tc.IToolRelease[] | undefined;
   let osPlat: string = os.platform();
@@ -72,7 +73,8 @@ export async function getGo(
       true,
       auth,
       arch,
-      manifest
+      manifest,
+      downloadBaseUrl
     );
     if (resolvedVersion) {
       versionSpec = resolvedVersion;
@@ -148,7 +150,8 @@ async function resolveVersionFromManifest(
   stable: boolean,
   auth: string | undefined,
   arch: string,
-  manifest: tc.IToolRelease[] | undefined
+  manifest: tc.IToolRelease[] | undefined,
+  downloadBaseUrl?: string | undefined
 ): Promise<string | undefined> {
   try {
     const info = await getInfoFromManifest(
@@ -156,7 +159,8 @@ async function resolveVersionFromManifest(
       stable,
       auth,
       arch,
-      manifest
+      manifest,
+      downloadBaseUrl
     );
     return info?.resolvedVersion;
   } catch (err) {
@@ -219,7 +223,8 @@ export async function getInfoFromManifest(
   stable: boolean,
   auth: string | undefined,
   arch = os.arch(),
-  manifest?: tc.IToolRelease[] | undefined
+  manifest?: tc.IToolRelease[] | undefined,
+  downloadBaseUrl?: string | undefined
 ): Promise<IGoVersionInfo | null> {
   let info: IGoVersionInfo | null = null;
   if (!manifest) {
@@ -236,6 +241,13 @@ export async function getInfoFromManifest(
     info.type = 'manifest';
     info.resolvedVersion = rel.version;
     info.downloadUrl = rel.files[0].download_url;
+    if (downloadBaseUrl) {
+      info.downloadUrl = info.downloadUrl.replace(
+        'https://github.com',
+        downloadBaseUrl
+      );
+    }
+
     info.fileName = rel.files[0].filename;
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ export async function run() {
     core.info(`Setup go version spec ${versionSpec}`);
 
     let arch = core.getInput('architecture');
+    let downloadBaseUrl = core.getInput('download-base-url');
 
     if (!arch) {
       arch = os.arch();
@@ -36,7 +37,8 @@ export async function run() {
         versionSpec,
         checkLatest,
         auth,
-        arch
+        arch,
+        downloadBaseUrl
       );
 
       const installDirVersion = path.basename(path.dirname(installDir));


### PR DESCRIPTION
… proxy

**Description:**
Add a download base url to use instead of the https://github.com

**Related issue:**
[Allow to proxy the files from versions-manifest.json.](https://github.com/actions/setup-go/issues/296)

**Check list:**
- [X] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.