### PR TITLE
Use actual version in cache

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -63605,7 +63605,8 @@ function run() {
             if (cache && cache_utils_1.isCacheFeatureAvailable()) {
                 const packageManager = 'default';
                 const cacheDependencyPath = core.getInput('cache-dependency-path');
-                core.info(`Version spec is ${versionSpec}`);
+                let goPath = yield io.which('go');
+                core.info(`Version spec is ${versionSpec}, go path is ${goPath}`);
                 yield cache_restore_1.restoreCache(versionSpec, packageManager, cacheDependencyPath);
             }
             // add problem matchers

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -63607,8 +63607,7 @@ function run() {
             if (cache && cache_utils_1.isCacheFeatureAvailable()) {
                 const packageManager = 'default';
                 const cacheDependencyPath = core.getInput('cache-dependency-path');
-                core.info(`Version spec is ${versionSpec}, go version is ${goVersion}`);
-                yield cache_restore_1.restoreCache(goVersion, packageManager, cacheDependencyPath);
+                yield cache_restore_1.restoreCache(parseGoVersion(goVersion), packageManager, cacheDependencyPath);
             }
             // add problem matchers
             const matchersPath = path_1.default.join(__dirname, '../..', 'matchers.json');

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -63605,6 +63605,7 @@ function run() {
             if (cache && cache_utils_1.isCacheFeatureAvailable()) {
                 const packageManager = 'default';
                 const cacheDependencyPath = core.getInput('cache-dependency-path');
+                core.info(`Version spec is ${versionSpec}`);
                 yield cache_restore_1.restoreCache(versionSpec, packageManager, cacheDependencyPath);
             }
             // add problem matchers

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -63602,19 +63602,18 @@ function run() {
                 core.debug(`add bin ${added}`);
                 core.info(`Successfully set up Go version ${versionSpec}`);
             }
+            let goPath = yield io.which('go');
+            let goVersion = (child_process_1.default.execSync(`${goPath} version`) || '').toString();
             if (cache && cache_utils_1.isCacheFeatureAvailable()) {
                 const packageManager = 'default';
                 const cacheDependencyPath = core.getInput('cache-dependency-path');
-                let goPath = yield io.which('go');
-                core.info(`Version spec is ${versionSpec}, go path is ${goPath}`);
-                yield cache_restore_1.restoreCache(versionSpec, packageManager, cacheDependencyPath);
+                core.info(`Version spec is ${versionSpec}, go version is ${goVersion}`);
+                yield cache_restore_1.restoreCache(goVersion, packageManager, cacheDependencyPath);
             }
             // add problem matchers
             const matchersPath = path_1.default.join(__dirname, '../..', 'matchers.json');
             core.info(`##[add-matcher]${matchersPath}`);
             // output the version actually being used
-            let goPath = yield io.which('go');
-            let goVersion = (child_process_1.default.execSync(`${goPath} version`) || '').toString();
             core.info(goVersion);
             core.setOutput('go-version', parseGoVersion(goVersion));
             core.startGroup('go env');

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,12 +56,14 @@ export async function run() {
       core.info(`Successfully set up Go version ${versionSpec}`);
     }
 
+    let goPath = await io.which('go');
+    let goVersion = (cp.execSync(`${goPath} version`) || '').toString();
+
     if (cache && isCacheFeatureAvailable()) {
       const packageManager = 'default';
       const cacheDependencyPath = core.getInput('cache-dependency-path');
-      let goPath = await io.which('go');
-      core.info(`Version spec is ${versionSpec}, go path is ${goPath}`)
-      await restoreCache(versionSpec, packageManager, cacheDependencyPath);
+      core.info(`Version spec is ${versionSpec}, go version is ${goVersion}`)
+      await restoreCache(goVersion, packageManager, cacheDependencyPath);
     }
 
     // add problem matchers
@@ -69,8 +71,6 @@ export async function run() {
     core.info(`##[add-matcher]${matchersPath}`);
 
     // output the version actually being used
-    let goPath = await io.which('go');
-    let goVersion = (cp.execSync(`${goPath} version`) || '').toString();
     core.info(goVersion);
 
     core.setOutput('go-version', parseGoVersion(goVersion));

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,6 +59,7 @@ export async function run() {
     if (cache && isCacheFeatureAvailable()) {
       const packageManager = 'default';
       const cacheDependencyPath = core.getInput('cache-dependency-path');
+      core.info(`Version spec is ${versionSpec}`)
       await restoreCache(versionSpec, packageManager, cacheDependencyPath);
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,7 +62,11 @@ export async function run() {
     if (cache && isCacheFeatureAvailable()) {
       const packageManager = 'default';
       const cacheDependencyPath = core.getInput('cache-dependency-path');
-      await restoreCache(parseGoVersion(goVersion), packageManager, cacheDependencyPath);
+      await restoreCache(
+        parseGoVersion(goVersion),
+        packageManager,
+        cacheDependencyPath
+      );
     }
 
     // add problem matchers

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,7 +59,8 @@ export async function run() {
     if (cache && isCacheFeatureAvailable()) {
       const packageManager = 'default';
       const cacheDependencyPath = core.getInput('cache-dependency-path');
-      core.info(`Version spec is ${versionSpec}`)
+      let goPath = await io.which('go');
+      core.info(`Version spec is ${versionSpec}, go path is ${goPath}`)
       await restoreCache(versionSpec, packageManager, cacheDependencyPath);
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,8 +62,7 @@ export async function run() {
     if (cache && isCacheFeatureAvailable()) {
       const packageManager = 'default';
       const cacheDependencyPath = core.getInput('cache-dependency-path');
-      core.info(`Version spec is ${versionSpec}, go version is ${goVersion}`)
-      await restoreCache(goVersion, packageManager, cacheDependencyPath);
+      await restoreCache(parseGoVersion(goVersion), packageManager, cacheDependencyPath);
     }
 
     // add problem matchers


### PR DESCRIPTION
**Description:**
Now the current version will be used for caching instead of `.x`, which will allow the cache to be used more efficiently

**Related issue:**
#280 
