### PR TITLE
feature: allow diversification using cache-key-suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,33 @@ steps:
       cache-dependency-path: subdir/go.sum
   - run: go run hello.go
   ```
+
+**Caching for different build profiles**
+Suppose you have multiple builds that depend on different dependencies, spread over multiple workflows or jobs. 
+If the same go.sum file is used, they will fight for the cache. Set `cache-key-suffix` to distinguish these caches.
+
+```yaml
+steps:
+  - uses: actions/checkout@v3
+  - uses: actions/setup-go@v3
+    with:
+      go-version: '1.17'
+      check-latest: true
+      cache: true
+      cache-key-suffix: hello
+  - run: go run hello.go
+
+# another workflow job
+steps:
+  - uses: actions/checkout@v3
+  - uses: actions/setup-go@v3
+    with:
+      go-version: '1.17'
+      check-latest: true
+      cache: true
+      cache-key-suffix: server
+  - run: go build -o /server ./cmd/
+  ```
 ## Getting go version from the go.mod file
 
 The `go-version-file` input accepts a path to a `go.mod` file or a `go.work` file that contains the version of Go to be used by a project. As the `go.mod` file contains only major and minor (e.g. 1.18) tags, the action will search for the latest available patch version sequentially in the runner's directory with the cached tools, in the [versions-manifest.json](https://github.com/actions/go-versions/blob/main/versions-manifest.json) file or at the go servers.

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,8 @@ inputs:
     default: false
   cache-dependency-path:
     description: 'Used to specify the path to a dependency file - go.sum'
+  cache-key-suffix:
+    description: 'Used to diversify the cache if you have multiple build targets in the same module - e.g. cmd1, cmd2'
   architecture:
     description: 'Target architecture for Go to use. Examples: x86, x64. Will use system architecture by default.'
 outputs:

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -63032,7 +63032,7 @@ const path_1 = __importDefault(__nccwpck_require__(1017));
 const fs_1 = __importDefault(__nccwpck_require__(7147));
 const constants_1 = __nccwpck_require__(9042);
 const cache_utils_1 = __nccwpck_require__(1678);
-const restoreCache = (versionSpec, packageManager, cacheDependencyPath) => __awaiter(void 0, void 0, void 0, function* () {
+const restoreCache = (versionSpec, packageManager, cacheDependencyPath, cacheKeySuffix) => __awaiter(void 0, void 0, void 0, function* () {
     const packageManagerInfo = yield cache_utils_1.getPackageManagerInfo(packageManager);
     const platform = process.env.RUNNER_OS;
     const cachePaths = yield cache_utils_1.getCacheDirectoryPath(packageManagerInfo);
@@ -63043,7 +63043,8 @@ const restoreCache = (versionSpec, packageManager, cacheDependencyPath) => __awa
     if (!fileHash) {
         throw new Error('Some specified paths were not resolved, unable to cache dependencies.');
     }
-    const primaryKey = `setup-go-${platform}-go-${versionSpec}-${fileHash}`;
+    const primaryKey = `setup-go-${platform}-go-${versionSpec}-${fileHash}${cacheKeySuffix ||
+        ''}`;
     core.debug(`primary key is ${primaryKey}`);
     core.saveState(constants_1.State.CachePrimaryKey, primaryKey);
     const cacheKey = yield cache.restoreCache(cachePaths, primaryKey);
@@ -63607,7 +63608,8 @@ function run() {
             if (cache && cache_utils_1.isCacheFeatureAvailable()) {
                 const packageManager = 'default';
                 const cacheDependencyPath = core.getInput('cache-dependency-path');
-                yield cache_restore_1.restoreCache(parseGoVersion(goVersion), packageManager, cacheDependencyPath);
+                const cacheKeySuffix = core.getInput('cache-key-suffix');
+                yield cache_restore_1.restoreCache(parseGoVersion(goVersion), packageManager, cacheDependencyPath, cacheKeySuffix);
             }
             // add problem matchers
             const matchersPath = path_1.default.join(__dirname, '../..', 'matchers.json');

--- a/src/cache-restore.ts
+++ b/src/cache-restore.ts
@@ -11,7 +11,8 @@ import {getCacheDirectoryPath, getPackageManagerInfo} from './cache-utils';
 export const restoreCache = async (
   versionSpec: string,
   packageManager: string,
-  cacheDependencyPath?: string
+  cacheDependencyPath?: string,
+  cacheKeySuffix?: string
 ) => {
   const packageManagerInfo = await getPackageManagerInfo(packageManager);
   const platform = process.env.RUNNER_OS;
@@ -29,7 +30,8 @@ export const restoreCache = async (
     );
   }
 
-  const primaryKey = `setup-go-${platform}-go-${versionSpec}-${fileHash}`;
+  const primaryKey = `setup-go-${platform}-go-${versionSpec}-${fileHash}${cacheKeySuffix ||
+    ''}`;
   core.debug(`primary key is ${primaryKey}`);
 
   core.saveState(State.CachePrimaryKey, primaryKey);

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,10 +62,12 @@ export async function run() {
     if (cache && isCacheFeatureAvailable()) {
       const packageManager = 'default';
       const cacheDependencyPath = core.getInput('cache-dependency-path');
+      const cacheKeySuffix = core.getInput('cache-key-suffix');
       await restoreCache(
         parseGoVersion(goVersion),
         packageManager,
-        cacheDependencyPath
+        cacheDependencyPath,
+        cacheKeySuffix
       );
     }
 


### PR DESCRIPTION
**Description:**
Any larger project with multiple cmd might build multiple binaries with distinct sets of dependencies. As https://github.com/actions/setup-go/issues/259 already indicated, those workflows will fight for the cache. Given workflow A & B, if any of those two finishes and is cached, any subsequent build reuses the same cache. Even if the build of B has a completely different `go-build` cache state. This means that for one of the workflows, the build will always be slow.

This is specifically a problem, when building both (tiny) plugins, and large server binaries (both in different pipelines). This requires a monorepo, because the plugin must use the exact same module versions, so the go.mod/go.sum files are the same, therefore `cache-dependency-path` **is not an option**.

Both should use the same `go env GOMODCACHE` (`go/pkg/mod`) but different `go env GOCACHE` (`go-build`).

Usage:

```yaml
# workflow job A
steps:
  - uses: actions/checkout@v3
  - uses: actions/setup-go@v3
    with:
      go-version: '1.19'
      cache: true
      cache-key-suffix: toolA
  - run: go run cmd/toolA/

# workflow job B
steps:
  - uses: actions/checkout@v3
  - uses: actions/setup-go@v3
    with:
      go-version: '1.19'
      cache: true
      cache-key-suffix: toolB
  - run: go run cmd/toolB/
```

**Related issue:**
Implements #324, #259

**Check list:**
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.