### PR TITLE
Skip cache restore on missing go.sum

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -63036,9 +63036,18 @@ const restoreCache = (versionSpec, packageManager, cacheDependencyPath) => __awa
     const packageManagerInfo = yield cache_utils_1.getPackageManagerInfo(packageManager);
     const platform = process.env.RUNNER_OS;
     const cachePaths = yield cache_utils_1.getCacheDirectoryPath(packageManagerInfo);
-    const dependencyFilePath = cacheDependencyPath
-        ? cacheDependencyPath
-        : findDependencyFile(packageManagerInfo);
+    let dependencyFilePath;
+    try {
+        core.info('Trying to resolve lockfile path.');
+        dependencyFilePath = cacheDependencyPath
+            ? cacheDependencyPath
+            : findDependencyFile(packageManagerInfo);
+    }
+    catch (e) {
+        core.info(e.message);
+        core.setOutput(constants_1.Outputs.CacheHit, false);
+        return;
+    }
     const fileHash = yield glob.hashFiles(dependencyFilePath);
     if (!fileHash) {
         throw new Error('Some specified paths were not resolved, unable to cache dependencies.');

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -63038,7 +63038,6 @@ const restoreCache = (versionSpec, packageManager, cacheDependencyPath) => __awa
     const cachePaths = yield cache_utils_1.getCacheDirectoryPath(packageManagerInfo);
     let dependencyFilePath;
     try {
-        core.info('Trying to resolve lockfile path.');
         dependencyFilePath = cacheDependencyPath
             ? cacheDependencyPath
             : findDependencyFile(packageManagerInfo);

--- a/src/cache-restore.ts
+++ b/src/cache-restore.ts
@@ -20,7 +20,6 @@ export const restoreCache = async (
 
   let dependencyFilePath: string;
   try {
-    core.info('Trying to resolve lockfile path.');
     dependencyFilePath = cacheDependencyPath
       ? cacheDependencyPath
       : findDependencyFile(packageManagerInfo);

--- a/src/cache-restore.ts
+++ b/src/cache-restore.ts
@@ -18,9 +18,16 @@ export const restoreCache = async (
 
   const cachePaths = await getCacheDirectoryPath(packageManagerInfo);
 
-  const dependencyFilePath = cacheDependencyPath
-    ? cacheDependencyPath
-    : findDependencyFile(packageManagerInfo);
+  let dependencyFilePath: string
+  try {
+    dependencyFilePath = cacheDependencyPath
+      ? cacheDependencyPath
+      : findDependencyFile(packageManagerInfo);
+  } catch (e) {
+    core.info(e);
+    core.setOutput(Outputs.CacheHit, false);
+    return;
+  }
   const fileHash = await glob.hashFiles(dependencyFilePath);
 
   if (!fileHash) {

--- a/src/cache-restore.ts
+++ b/src/cache-restore.ts
@@ -20,11 +20,12 @@ export const restoreCache = async (
 
   let dependencyFilePath: string
   try {
+    core.info('Trying to resolve lockfile path.');
     dependencyFilePath = cacheDependencyPath
       ? cacheDependencyPath
       : findDependencyFile(packageManagerInfo);
   } catch (e) {
-    core.info(e);
+    core.info(e.message);
     core.setOutput(Outputs.CacheHit, false);
     return;
   }

--- a/src/cache-restore.ts
+++ b/src/cache-restore.ts
@@ -18,7 +18,7 @@ export const restoreCache = async (
 
   const cachePaths = await getCacheDirectoryPath(packageManagerInfo);
 
-  let dependencyFilePath: string
+  let dependencyFilePath: string;
   try {
     core.info('Trying to resolve lockfile path.');
     dependencyFilePath = cacheDependencyPath


### PR DESCRIPTION
**Description:**
When the action attempted to restore a cache and the go.sum file was missing, it crashed.
With this change, the cache restore will be skipped if a go.sum lockfile is missing.

**Related issue:**
#266
#270

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.