### PR TITLE
Add JSON output of `go env` and some env as strings

### DIFF
--- a/.github/workflows/outputs.yml
+++ b/.github/workflows/outputs.yml
@@ -1,0 +1,24 @@
+name: Test outputs
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  setup-go-env:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - id: setup-go
+        uses: ./
+      - run: |
+          echo GOPATH=${{ steps.setup-go.outputs.go-path }}
+          echo GOMOD=${{ steps.setup-go.outputs.go-mod }}
+          echo GOMODCACHE=${{ steps.setup-go.outputs.go-mod-cache }}
+          echo GOVERSION=${{ steps.setup-go.outputs.go-version }}
+          echo GOCACHE=${{ steps.setup-go.outputs.go-cache }}
+
+          echo Go environment variables json:
+          jq . <<< '${{ steps.setup-go.outputs.go-env }}'

--- a/__tests__/setup-go.test.ts
+++ b/__tests__/setup-go.test.ts
@@ -143,6 +143,29 @@ describe('setup-go', () => {
     expect(main.parseGoVersion(goVersionOutput)).toBe('1.16.6');
   });
 
+  it('can read go env variables', async () => {
+    const goRoot = '/opt/hostedtoolcache/go/1.18.10/x64';
+    const goPath = '/home/runner/go';
+    const goModCache = '/home/runner/go/pkg/mod';
+    const goCache = '/home/runner/.cache/go-build';
+    const goVersion = 'go1.18.10';
+
+    const env = `
+GOROOT="${goRoot}"
+GOPATH="${goPath}"
+GOMODCACHE="${goModCache}"
+GOCACHE="${goCache}"
+GOVERSION="${goVersion}"
+    `;
+    const json = JSON.parse(main.convertEnvStringToJson(env));
+    expect(json).toBeDefined();
+    expect(json['GOROOT']).toBe(goRoot);
+    expect(json['GOPATH']).toBe(goPath);
+    expect(json['GOMODCACHE']).toBe(goModCache);
+    expect(json['GOCACHE']).toBe(goCache);
+    expect(json['GOVERSION']).toBe(goVersion);
+  });
+
   it('can find 1.9.7 from manifest on osx', async () => {
     os.platform = 'darwin';
     os.arch = 'x64';

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,18 @@ inputs:
 outputs:
   go-version:
     description: 'The installed Go version. Useful when given a version range as input.'
+  go-cache:
+    description: 'The GOCACHE environment variable'
+  go-path:
+    description: 'The GOPATH environment variable'
+  go-root:
+    description: 'The GOROOT environment variable'
+  go-mod:
+    description: 'The GOMOD environment variable'
+  go-mod-cache:
+    description: 'The GOMODCACHE environment variable'
+  go-env:
+    description: 'The Go environment variables in JSON format'
   cache-hit:
     description: 'A boolean value to indicate if a cache was hit'
 runs:


### PR DESCRIPTION
**Description:**
Additional outputs are:
- GOPATH as `go-path` string
~- GOROOT as `go-root` string~
- GOMOD as `go-mod` string
- GOCACHE as `go-cache` string
- GOMODCACHE as `go-mod-cache` string
- `go env` as `go-env` JSON

**Related issue:**
Closes #54 

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.