### PR TITLE
Add step warning if go-version input is empty

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -63600,6 +63600,9 @@ function run() {
                 core.debug(`add bin ${added}`);
                 core.info(`Successfully set up Go version ${versionSpec}`);
             }
+            else {
+                core.info('[warning]go-version input was not specified. The action will try to use pre-installed version.');
+            }
             const goPath = yield io.which('go');
             const goVersion = (child_process_1.default.execSync(`${goPath} version`) || '').toString();
             if (cache && cache_utils_1.isCacheFeatureAvailable()) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,6 +54,10 @@ export async function run() {
       const added = await addBinToPath();
       core.debug(`add bin ${added}`);
       core.info(`Successfully set up Go version ${versionSpec}`);
+    } else {
+      core.info(
+        '[warning]go-version input was not specified. The action will try to use pre-installed version.'
+      );
     }
 
     const goPath = await io.which('go');


### PR DESCRIPTION
**Description:**
In scope of this pull request we add step warning if go-version input is empty

**Related issue:**
https://github.com/actions/setup-go/issues/83

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.