### PR TITLE
Add Go bin if go-version input is empty

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -63596,10 +63596,10 @@ function run() {
                     core.info('Setting GOROOT for Go version < 1.9');
                     core.exportVariable('GOROOT', installDir);
                 }
-                const added = yield addBinToPath();
-                core.debug(`add bin ${added}`);
-                core.info(`Successfully set up Go version ${versionSpec}`);
             }
+            const added = yield addBinToPath();
+            core.debug(`add bin ${added}`);
+            core.info(`Successfully set up Go version ${versionSpec}`);
             const goPath = yield io.which('go');
             const goVersion = (child_process_1.default.execSync(`${goPath} version`) || '').toString();
             if (cache && cache_utils_1.isCacheFeatureAvailable()) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,6 +50,8 @@ export async function run() {
         core.info('Setting GOROOT for Go version < 1.9');
         core.exportVariable('GOROOT', installDir);
       }
+      
+      core.info(`Successfully set up Go version ${versionSpec}`);
     } else {
       core.info(
         '[warning]go-version input was not specified. The action will try to use pre-installed version.'
@@ -58,7 +60,6 @@ export async function run() {
 
     const added = await addBinToPath();
     core.debug(`add bin ${added}`);
-    core.info(`Successfully set up Go version ${versionSpec}`);
 
     const goPath = await io.which('go');
     const goVersion = (cp.execSync(`${goPath} version`) || '').toString();

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,7 +50,7 @@ export async function run() {
         core.info('Setting GOROOT for Go version < 1.9');
         core.exportVariable('GOROOT', installDir);
       }
-      
+
       core.info(`Successfully set up Go version ${versionSpec}`);
     } else {
       core.info(

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,11 +50,11 @@ export async function run() {
         core.info('Setting GOROOT for Go version < 1.9');
         core.exportVariable('GOROOT', installDir);
       }
-
-      const added = await addBinToPath();
-      core.debug(`add bin ${added}`);
-      core.info(`Successfully set up Go version ${versionSpec}`);
     }
+
+    const added = await addBinToPath();
+    core.debug(`add bin ${added}`);
+    core.info(`Successfully set up Go version ${versionSpec}`);
 
     const goPath = await io.which('go');
     const goVersion = (cp.execSync(`${goPath} version`) || '').toString();


### PR DESCRIPTION
**Description:**
In scope of this pull request we update logic to add Go bin even if go-version input is empty. 

**Related issue:**
https://github.com/actions/setup-go/issues/49

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.