### PR TITLE
Add cache-restore-only input

### DIFF
--- a/__tests__/setup-go.test.ts
+++ b/__tests__/setup-go.test.ts
@@ -242,7 +242,7 @@ describe('setup-go', () => {
     await main.run();
 
     expect(logSpy).toHaveBeenCalledWith(`Setup go version spec 1.13.0`);
-  });
+  }, 60000);
 
   it('evaluates to stable with no input', async () => {
     inputs['go-version'] = '1.13.0';

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
     default: true
   cache-dependency-path:
     description: 'Used to specify the path to a dependency file - go.sum'
+  cache-restore-only:
+    description: 'Set this option to true if you do not want to modify the cache from the previous build'
+    default: false
   architecture:
     description: 'Target architecture for Go to use. Examples: x86, x64. Will use system architecture by default.'
 outputs:

--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -60363,7 +60363,8 @@ function run() {
 exports.run = run;
 const cachePackages = () => __awaiter(void 0, void 0, void 0, function* () {
     const cacheInput = core.getBooleanInput('cache');
-    if (!cacheInput) {
+    const cacheRestoreOnly = core.getBooleanInput('cache-restore-only');
+    if (!cacheInput || cacheRestoreOnly) {
         return;
     }
     const packageManager = 'default';

--- a/src/cache-save.ts
+++ b/src/cache-save.ts
@@ -29,7 +29,8 @@ export async function run() {
 
 const cachePackages = async () => {
   const cacheInput = core.getBooleanInput('cache');
-  if (!cacheInput) {
+  const cacheRestoreOnly = core.getBooleanInput('cache-restore-only');
+  if (!cacheInput || cacheRestoreOnly) {
     return;
   }
 


### PR DESCRIPTION
**Description:**
In bigger repos, it's easy to hit the 10gb cache limit. Not caching in PRs can help with this.

**Related issue:**
[Add link to the related issue.](https://github.com/actions/setup-go/issues/316)

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.