### PR TITLE
feat: Add `cache-key-prefix` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ The `cache` input is optional, and caching is turned on by default.
 The action defaults to search for the dependency file - go.sum in the repository root, and uses its hash as a part of
 the cache key. Use `cache-dependency-path` input for cases when multiple dependency files are used, or they are located
 in different subdirectories.
+If you use `setup-go` with caching from multiple concurrent jobs, you might want to specify the `cache-key-prefix` input to ensure that the cache is not shared between jobs.
 
 If some problem that prevents success caching happens then the action issues the warning in the log and continues the execution of the pipeline. 
 
@@ -168,6 +169,30 @@ steps:
       cache-dependency-path: subdir/go.sum
   - run: go run hello.go
   ```
+
+**Caching wwith multiple concurrent jobs**
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.20"
+          cache-key-prefix: build-cache-
+      - run: go build
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.20"
+          cache-key-prefix: test-cache-
+      - run: go test ./...
+```
 
 ## Getting go version from the go.mod file
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: "1.20"
-          cache-key-prefix: build-cache-
+          cache-key-prefix: build-cache
       - run: go build
   test:
     runs-on: ubuntu-latest
@@ -190,7 +190,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: "1.20"
-          cache-key-prefix: test-cache-
+          cache-key-prefix: test-cache
       - run: go test ./...
 ```
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ steps:
   - run: go run hello.go
   ```
 
-**Caching wwith multiple concurrent jobs**
+**Caching with multiple concurrent jobs**
 
 ```yaml
 jobs:

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,7 @@ inputs:
     description: 'Used to specify the path to a dependency file - go.sum'
   cache-key-prefix:
     description: 'A prefix to add to the cache key. Useful if you have multiple concurrent jobs that need different caches.'
+    default: 'setup-go'
   architecture:
     description: 'Target architecture for Go to use. Examples: x86, x64. Will use system architecture by default.'
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,8 @@ inputs:
     default: true
   cache-dependency-path:
     description: 'Used to specify the path to a dependency file - go.sum'
+  cache-key-prefix:
+    description: 'A prefix to add to the cache key. Useful if you have multiple concurrent jobs that need different caches.'
   architecture:
     description: 'Target architecture for Go to use. Examples: x86, x64. Will use system architecture by default.'
 outputs:

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -63043,7 +63043,8 @@ const restoreCache = (versionSpec, packageManager, cacheDependencyPath) => __awa
     if (!fileHash) {
         throw new Error('Some specified paths were not resolved, unable to cache dependencies.');
     }
-    const primaryKey = `setup-go-${platform}-go-${versionSpec}-${fileHash}`;
+    const cacheKeyPrefix = core.getInput('cache-key-prefix') || '';
+    const primaryKey = `${cacheKeyPrefix}setup-go-${platform}-go-${versionSpec}-${fileHash}`;
     core.debug(`primary key is ${primaryKey}`);
     core.saveState(constants_1.State.CachePrimaryKey, primaryKey);
     const cacheKey = yield cache.restoreCache(cachePaths, primaryKey);

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -63043,8 +63043,8 @@ const restoreCache = (versionSpec, packageManager, cacheDependencyPath) => __awa
     if (!fileHash) {
         throw new Error('Some specified paths were not resolved, unable to cache dependencies.');
     }
-    const cacheKeyPrefix = core.getInput('cache-key-prefix') || '';
-    const primaryKey = `${cacheKeyPrefix}setup-go-${platform}-go-${versionSpec}-${fileHash}`;
+    const cacheKeyPrefix = core.getInput('cache-key-prefix') || 'setup-go';
+    const primaryKey = `${cacheKeyPrefix}-${platform}-go-${versionSpec}-${fileHash}`;
     core.debug(`primary key is ${primaryKey}`);
     core.saveState(constants_1.State.CachePrimaryKey, primaryKey);
     const cacheKey = yield cache.restoreCache(cachePaths, primaryKey);

--- a/src/cache-restore.ts
+++ b/src/cache-restore.ts
@@ -29,8 +29,8 @@ export const restoreCache = async (
     );
   }
 
-  const cacheKeyPrefix = core.getInput('cache-key-prefix') || '';
-  const primaryKey = `${cacheKeyPrefix}setup-go-${platform}-go-${versionSpec}-${fileHash}`;
+  const cacheKeyPrefix = core.getInput('cache-key-prefix') || 'setup-go'
+  const primaryKey = `${cacheKeyPrefix}-${platform}-go-${versionSpec}-${fileHash}`;
   core.debug(`primary key is ${primaryKey}`);
 
   core.saveState(State.CachePrimaryKey, primaryKey);

--- a/src/cache-restore.ts
+++ b/src/cache-restore.ts
@@ -29,7 +29,8 @@ export const restoreCache = async (
     );
   }
 
-  const primaryKey = `setup-go-${platform}-go-${versionSpec}-${fileHash}`;
+  const cacheKeyPrefix = core.getInput('cache-key-prefix') || '';
+  const primaryKey = `${cacheKeyPrefix}setup-go-${platform}-go-${versionSpec}-${fileHash}`;
   core.debug(`primary key is ${primaryKey}`);
 
   core.saveState(State.CachePrimaryKey, primaryKey);

--- a/src/cache-restore.ts
+++ b/src/cache-restore.ts
@@ -29,7 +29,7 @@ export const restoreCache = async (
     );
   }
 
-  const cacheKeyPrefix = core.getInput('cache-key-prefix') || 'setup-go'
+  const cacheKeyPrefix = core.getInput('cache-key-prefix') || 'setup-go';
   const primaryKey = `${cacheKeyPrefix}-${platform}-go-${versionSpec}-${fileHash}`;
   core.debug(`primary key is ${primaryKey}`);
 


### PR DESCRIPTION
**Description:**

Adds a cache key prefix option so it's possible to use different cache keys for different jobs

**Related issue:**

Fixes https://github.com/actions/setup-go/issues/358

**Check list:**
- [x] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.