### PR TITLE
Add imageOS to primaryKey

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -61155,7 +61155,8 @@ const restoreCache = (versionSpec, packageManager, cacheDependencyPath) => __awa
     if (!fileHash) {
         throw new Error('Some specified paths were not resolved, unable to cache dependencies.');
     }
-    const primaryKey = `setup-go-${platform}-go-${versionSpec}-${fileHash}`;
+    const imageOS = process.env.ImageOS || 'self-hosted';
+    const primaryKey = `setup-go-${platform}-${imageOS}-go-${versionSpec}-${fileHash}`;
     core.debug(`primary key is ${primaryKey}`);
     core.saveState(constants_1.State.CachePrimaryKey, primaryKey);
     const cacheKey = yield cache.restoreCache(cachePaths, primaryKey);

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -61155,8 +61155,8 @@ const restoreCache = (versionSpec, packageManager, cacheDependencyPath) => __awa
     if (!fileHash) {
         throw new Error('Some specified paths were not resolved, unable to cache dependencies.');
     }
-    const imageOS = process.env.ImageOS || 'self-hosted';
-    const primaryKey = `setup-go-${platform}-${imageOS}-go-${versionSpec}-${fileHash}`;
+    const linuxVersion = process.env.RUNNER_OS === 'Linux' ? `${process.env.ImageOS}-` : '';
+    const primaryKey = `setup-go-${platform}-${linuxVersion}go-${versionSpec}-${fileHash}`;
     core.debug(`primary key is ${primaryKey}`);
     core.saveState(constants_1.State.CachePrimaryKey, primaryKey);
     const cacheKey = yield cache.restoreCache(cachePaths, primaryKey);

--- a/src/cache-restore.ts
+++ b/src/cache-restore.ts
@@ -29,8 +29,9 @@ export const restoreCache = async (
     );
   }
 
-  const imageOS = process.env.ImageOS || 'self-hosted';
-  const primaryKey = `setup-go-${platform}-${imageOS}-go-${versionSpec}-${fileHash}`;
+  const linuxVersion =
+    process.env.RUNNER_OS === 'Linux' ? `${process.env.ImageOS}-` : '';
+  const primaryKey = `setup-go-${platform}-${linuxVersion}go-${versionSpec}-${fileHash}`;
   core.debug(`primary key is ${primaryKey}`);
 
   core.saveState(State.CachePrimaryKey, primaryKey);

--- a/src/cache-restore.ts
+++ b/src/cache-restore.ts
@@ -29,7 +29,8 @@ export const restoreCache = async (
     );
   }
 
-  const primaryKey = `setup-go-${platform}-go-${versionSpec}-${fileHash}`;
+  const imageOS = process.env.ImageOS || 'self-hosted';
+  const primaryKey = `setup-go-${platform}-${imageOS}-go-${versionSpec}-${fileHash}`;
   core.debug(`primary key is ${primaryKey}`);
 
   core.saveState(State.CachePrimaryKey, primaryKey);


### PR DESCRIPTION
**Description:**
Cache key now contains the os version in order to avoid conflicts between the binaries built against the unexpected libraries

TBD: the original issue explicitly mentions Linux as the os having issue. Probably the solution should be limited to Linux only.

**Related issue:**
[link to the related issue.](https://github.com/actions/setup-go/issues/368)

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.