### PR TITLE
fix: Make Go installer respect cache input

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -34,7 +34,8 @@ export async function getGo(
   versionSpec: string,
   checkLatest: boolean,
   auth: string | undefined,
-  arch = os.arch()
+  arch = os.arch(),
+  cache: boolean
 ) {
   let manifest: tc.IToolRelease[] | undefined;
   const osPlat: string = os.platform();
@@ -83,11 +84,13 @@ export async function getGo(
   }
 
   // check cache
-  const toolPath = tc.find('go', versionSpec, arch);
-  // If not found in cache, download
-  if (toolPath) {
-    core.info(`Found in cache @ ${toolPath}`);
-    return toolPath;
+  if (cache) {
+    const toolPath = tc.find('go', versionSpec, arch);
+    // If not found in cache, download
+    if (toolPath) {
+      core.info(`Found in cache @ ${toolPath}`);
+      return toolPath;
+    }
   }
   core.info(`Attempting to download ${versionSpec}...`);
   let downloadPath = '';

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,8 @@ export async function run() {
         versionSpec,
         checkLatest,
         auth,
-        arch
+        arch, 
+        cache
       );
 
       const installDirVersion = path.basename(path.dirname(installDir));


### PR DESCRIPTION
**Description:**
In the latest release, even if the input `cache` is explicitly set to false, the go installer will use `actions/tool-cache` library to check for a go binary in an available cache. 

**How to reproduce**
You can reproduce this issue by first running the action with cache enabled (the default since v4 I believe), and then explicitly disable cache, until the cache is actually deleted, the go binary is still cached. 


This PR makes sure the cache input in taken into account by the go installer. 

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.