### PR TITLE
Fix Install on Windows is very slow

### DIFF
--- a/.github/workflows/windows-validation.yml
+++ b/.github/workflows/windows-validation.yml
@@ -1,4 +1,4 @@
-name: validate Windows installation
+name: Validate Windows installation
 
 on:
   push:
@@ -13,7 +13,7 @@ on:
 jobs:
   create-link-if-not-default:
     runs-on: windows-latest
-    name: 'Setup ${{ matrix.go }}, cache: ${{ matrix.cache }}'
+    name: 'Validate if symlink is created'
     strategy:
       matrix:
         cache: [false, true]
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: non-default-cache-${{ matrix.cache }}-${{ matrix.go }}
+      - name: 'Setup ${{ matrix.cache }}, cache: ${{ matrix.go }}'
         uses: ./
         with:
           go-version: ${{ matrix.go }}
@@ -81,7 +81,7 @@ jobs:
         shell: bash
 
   dont-create-link-if-default:
-    name: 'Use default go, cache: ${{ matrix.cache }}'
+    name: 'Validate if symlink is not created for default go'
     runs-on: windows-latest
     needs: find-default-go
     strategy:
@@ -90,12 +90,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: ./
+      - name: 'Setup default go, cache: ${{ matrix.cache }}'
+        uses: ./
         with:
           go-version: ${{ needs.find-default-go.outputs.version }}
           cache: ${{ matrix.cache }}
 
-      - name: 'Drive C: should have Go installation'
+      - name: 'Drive C: should have Go installation, cache: ${{ matrix.cache}}'
         run: |
           size=$(du -m -s 'C:\hostedtoolcache\windows\go\${{ needs.find-default-go.outputs.version }}\x64'|cut -f1 -d$'\t')
           if [ $size -eq 0 ];then
@@ -104,7 +105,7 @@ jobs:
           fi
         shell: bash
 
-      - name: 'Drive D: should not have Go installation'
+      - name: 'Drive D: should not have Go installation, cache: ${{ matrix.cache}}'
         run: |
           if [ -e 'D:\hostedtoolcache\windows\go\${{ needs.find-default-go.outputs.version }}\x64' ];then
             echo 'D:\hostedtoolcache\windows\go\${{ needs.find-default-go.outputs.version }}\x64 should not exist for hosted version of go';

--- a/.github/workflows/windows-validation.yml
+++ b/.github/workflows/windows-validation.yml
@@ -29,7 +29,7 @@ jobs:
       - run: |
           du -m -s 'D:\hostedtoolcache\windows\go\${{ matrix.go }}\x64'
           size=$(du -m -s 'D:\hostedtoolcache\windows\go\${{ matrix.go }}\x64'|cut -f1 -d$'\t')
-          # make sure archive does not take lost of the space
+          # make sure archive does not take lot of space
           if [ $size -gt 999 ];then
             echo 'Size of installed on drive d: go is too big';
             exit 1

--- a/.github/workflows/windows-validation.yml
+++ b/.github/workflows/windows-validation.yml
@@ -1,4 +1,4 @@
-name: Basic validation
+name: validate Windows installation
 
 on:
   push:
@@ -16,7 +16,8 @@ jobs:
     strategy:
       matrix:
         cache: [false, true]
-        go: [1.20.1]
+        go: [1.20.1, 1.20.5]
+    name: 'Setup ${{ matrix.go }} cache: ${{ matrix.cache }}'
     steps:
       - uses: actions/checkout@v3
 
@@ -25,6 +26,23 @@ jobs:
           go-version: ${{ matrix.go }}
           cache: ${{ matrix.cache }}
         name: v4-cache-${{ matrix.cache }}
+
+      - run: |
+          if [ -e 'D:\hostedtoolcache\windows\go\${{ matrix.go }}\x64' ];then
+            echo 'D:\hostedtoolcache\windows\go\${{ matrix.go }}\x64 should not exist for hosted version of go';
+            exit 1
+          fi
+
+          du -m -s 'C:\hostedtoolcache\windows\go\${{ matrix.go }}\x64'
+          # make sure drive c: contains the folder
+          size=$(du -m -s 'C:\hostedtoolcache\windows\go\${{ matrix.go }}\x64'|cut -f1 -d$'\t')
+          if [ $size -eq 0 ];then
+            echo 'Size of the hosted go installed on drive c: must be above zero'
+            exit 1
+          fi
+        shell: bash
+        name: Hosted go should not have link
+        if: ${{ matrix.go == '1.20.5' }}
 
       - run: |
           du -m -s 'D:\hostedtoolcache\windows\go\${{ matrix.go }}\x64'
@@ -44,6 +62,7 @@ jobs:
           fi
         shell: bash
         name: Disk usage
+        if: ${{ matrix.go != '1.20.5' }}
 
       - run: |
           echo $PATH
@@ -54,8 +73,8 @@ jobs:
             echo 'which go should return "/c/hostedtoolcache/windows/go/${{ matrix.go }}/x64/bin/go"'
             exit 1
           fi
-          if [ $(go env GOROOT) != 'C:\hostedtoolcache\windows\go\1.20.1\x64' ];then 
-            echo 'go env GOROOT should return "C:\hostedtoolcache\windows\go\1.20.1\x64"'
+          if [ $(go env GOROOT) != 'C:\hostedtoolcache\windows\go\${{ matrix.go }}\x64' ];then 
+            echo 'go env GOROOT should return "C:\hostedtoolcache\windows\go\${{ matrix.go }}\x64"'
             exit 1
           fi
         shell: bash

--- a/.github/workflows/windows-validation.yml
+++ b/.github/workflows/windows-validation.yml
@@ -1,0 +1,62 @@
+name: Basic validation
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  create-link-on-windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        cache: [false, true]
+        go: [1.20.1]
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: ./
+        with:
+          go-version: ${{ matrix.go }}
+          cache: ${{ matrix.cache }}
+        name: v4-cache-${{ matrix.cache }}
+
+      - run: |
+          du -m -s 'D:\hostedtoolcache\windows\go\${{ matrix.go }}\x64'
+          size=$(du -m -s 'D:\hostedtoolcache\windows\go\${{ matrix.go }}\x64'|cut -f1 -d$'\t')
+          # make sure archive does not take lost of the space
+          if [ $size -gt 999 ];then
+            echo 'Size of installed on drive d: go is too big';
+            exit 1
+          fi
+
+          du -m -s 'C:\hostedtoolcache\windows\go\${{ matrix.go }}\x64'
+          # make sure drive c: contains only a link
+          size=$(du -m -s 'C:\hostedtoolcache\windows\go\${{ matrix.go }}\x64'|cut -f1 -d$'\t')
+          if [ $size -ne 0 ];then
+            echo 'Size of the link created on drive c: must be 0'
+            exit 1
+          fi
+        shell: bash
+        name: Disk usage
+
+      - run: |
+          echo $PATH
+          which go
+          go version
+          go env
+          if [ $(which go) != '/c/hostedtoolcache/windows/go/${{ matrix.go }}/x64/bin/go' ];then
+            echo 'which go should return "/c/hostedtoolcache/windows/go/${{ matrix.go }}/x64/bin/go"'
+            exit 1
+          fi
+          if [ $(go env GOROOT) != 'C:\hostedtoolcache\windows\go\1.20.1\x64' ];then 
+            echo 'go env GOROOT should return "C:\hostedtoolcache\windows\go\1.20.1\x64"'
+            exit 1
+          fi
+        shell: bash
+        name: test paths and environments

--- a/.github/workflows/windows-validation.yml
+++ b/.github/workflows/windows-validation.yml
@@ -11,48 +11,24 @@ on:
       - '**.md'
 
 jobs:
-  create-link-on-windows:
+  create-link-if-not-default:
     runs-on: windows-latest
+    name: 'Setup ${{ matrix.go }}, cache: ${{ matrix.cache }}'
     strategy:
       matrix:
         cache: [false, true]
-        go: [1.20.1, 1.20.5]
-    name: 'Setup ${{ matrix.go }} cache: ${{ matrix.cache }}'
+        go: [1.20.1]
     steps:
       - uses: actions/checkout@v3
 
-      - uses: ./
+      - name: non-default-cache-${{ matrix.cache }}-${{ matrix.go }}
+        uses: ./
         with:
           go-version: ${{ matrix.go }}
           cache: ${{ matrix.cache }}
-        name: v4-cache-${{ matrix.cache }}
 
-      - run: |
-          if [ -e 'D:\hostedtoolcache\windows\go\${{ matrix.go }}\x64' ];then
-            echo 'D:\hostedtoolcache\windows\go\${{ matrix.go }}\x64 should not exist for hosted version of go';
-            exit 1
-          fi
-
-          du -m -s 'C:\hostedtoolcache\windows\go\${{ matrix.go }}\x64'
-          # make sure drive c: contains the folder
-          size=$(du -m -s 'C:\hostedtoolcache\windows\go\${{ matrix.go }}\x64'|cut -f1 -d$'\t')
-          if [ $size -eq 0 ];then
-            echo 'Size of the hosted go installed on drive c: must be above zero'
-            exit 1
-          fi
-        shell: bash
-        name: Hosted go should not have link
-        if: ${{ matrix.go == '1.20.5' }}
-
-      - run: |
-          du -m -s 'D:\hostedtoolcache\windows\go\${{ matrix.go }}\x64'
-          size=$(du -m -s 'D:\hostedtoolcache\windows\go\${{ matrix.go }}\x64'|cut -f1 -d$'\t')
-          # make sure archive does not take lot of space
-          if [ $size -gt 999 ];then
-            echo 'Size of installed on drive d: go is too big';
-            exit 1
-          fi
-
+      - name: 'Drive C: should have zero size link'
+        run: |
           du -m -s 'C:\hostedtoolcache\windows\go\${{ matrix.go }}\x64'
           # make sure drive c: contains only a link
           size=$(du -m -s 'C:\hostedtoolcache\windows\go\${{ matrix.go }}\x64'|cut -f1 -d$'\t')
@@ -61,10 +37,22 @@ jobs:
             exit 1
           fi
         shell: bash
-        name: Disk usage
-        if: ${{ matrix.go != '1.20.5' }}
 
-      - run: |
+      # Drive D: is small, take care the action does not eat up the space
+      - name: 'Drive D: space usage should be below 1G'
+        run: |
+          du -m -s 'D:\hostedtoolcache\windows\go\${{ matrix.go }}\x64'
+          size=$(du -m -s 'D:\hostedtoolcache\windows\go\${{ matrix.go }}\x64'|cut -f1 -d$'\t')
+          # make sure archive does not take lot of space
+          if [ $size -gt 999 ];then
+            echo 'Size of installed on drive d: go is too big';
+            exit 1
+          fi
+        shell: bash
+
+      # make sure the Go installation has not been changed to the end user
+      - name: Test paths and environments
+        run: |
           echo $PATH
           which go
           go version
@@ -78,4 +66,48 @@ jobs:
             exit 1
           fi
         shell: bash
-        name: test paths and environments
+
+  find-default-go:
+    name: 'Find default go version'
+    runs-on: windows-latest
+    outputs:
+      version: ${{ steps.goversion.outputs.version }}
+    steps:
+      - run: |
+          version=`go env GOVERSION|sed s/^go//`
+          echo "default go version: $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+        id: goversion
+        shell: bash
+
+  dont-create-link-if-default:
+    name: 'Use default go, cache: ${{ matrix.cache }}'
+    runs-on: windows-latest
+    needs: find-default-go
+    strategy:
+      matrix:
+        cache: [false, true]
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: ./
+        with:
+          go-version: ${{ needs.find-default-go.outputs.version }}
+          cache: ${{ matrix.cache }}
+
+      - name: 'Drive C: should have Go installation'
+        run: |
+          size=$(du -m -s 'C:\hostedtoolcache\windows\go\${{ needs.find-default-go.outputs.version }}\x64'|cut -f1 -d$'\t')
+          if [ $size -eq 0 ];then
+            echo 'Size of the hosted go installed on drive c: must be above zero'
+            exit 1
+          fi
+        shell: bash
+
+      - name: 'Drive D: should not have Go installation'
+        run: |
+          if [ -e 'D:\hostedtoolcache\windows\go\${{ needs.find-default-go.outputs.version }}\x64' ];then
+            echo 'D:\hostedtoolcache\windows\go\${{ needs.find-default-go.outputs.version }}\x64 should not exist for hosted version of go';
+            exit 1
+          fi
+        shell: bash

--- a/__tests__/setup-go.test.ts
+++ b/__tests__/setup-go.test.ts
@@ -40,6 +40,8 @@ describe('setup-go', () => {
   let existsSpy: jest.SpyInstance;
   let readFileSpy: jest.SpyInstance;
   let mkdirpSpy: jest.SpyInstance;
+  let mkdirSpy: jest.SpyInstance;
+  let symlinkSpy: jest.SpyInstance;
   let execSpy: jest.SpyInstance;
   let getManifestSpy: jest.SpyInstance;
   let getAllVersionsSpy: jest.SpyInstance;
@@ -92,6 +94,11 @@ describe('setup-go', () => {
     existsSpy = jest.spyOn(fs, 'existsSync');
     readFileSpy = jest.spyOn(fs, 'readFileSync');
     mkdirpSpy = jest.spyOn(io, 'mkdirP');
+
+    // fs
+    mkdirSpy = jest.spyOn(fs, 'mkdir');
+    symlinkSpy = jest.spyOn(fs, 'symlinkSync');
+    symlinkSpy.mockImplementation(() => {});
 
     // gets
     getManifestSpy.mockImplementation(() => <tc.IToolRelease[]>goTestManifest);
@@ -957,40 +964,5 @@ use .
         );
       }
     );
-  });
-
-  describe('Windows performance workaround', () => {
-    it('addExecutablesToCache should depends on env[RUNNER_TOOL_CACHE]', async () => {
-      const statSpy = jest.spyOn(fs, 'statSync');
-      // @ts-ignore - not implement unused methods
-      statSpy.mockImplementation(() => ({
-        isDirectory: () => true
-      }));
-      const readdirSpy = jest.spyOn(fs, 'readdirSync');
-      readdirSpy.mockImplementation(() => []);
-      const writeFileSpy = jest.spyOn(fs, 'writeFileSync');
-      writeFileSpy.mockImplementation(() => {});
-      const rmRFSpy = jest.spyOn(io, 'rmRF');
-      rmRFSpy.mockImplementation(() => Promise.resolve());
-      const mkdirPSpy = jest.spyOn(io, 'mkdirP');
-      mkdirPSpy.mockImplementation(() => Promise.resolve());
-      const cpSpy = jest.spyOn(io, 'cp');
-      cpSpy.mockImplementation(() => Promise.resolve());
-
-      const info: IGoVersionInfo = {
-        type: 'dist',
-        downloadUrl: 'http://nowhere.com',
-        resolvedVersion: '1.2.3',
-        fileName: 'ignore'
-      };
-
-      process.env['RUNNER_TOOL_CACHE'] = '/faked-hostedtoolcache1';
-      const cacheDir1 = await addExecutablesToCache('/qzx', info, 'arch');
-      expect(cacheDir1).toBe('/faked-hostedtoolcache1/go/1.2.3/arch');
-
-      process.env['RUNNER_TOOL_CACHE'] = '/faked-hostedtoolcache2';
-      const cacheDir2 = await addExecutablesToCache('/qzx', info, 'arch');
-      expect(cacheDir2).toBe('/faked-hostedtoolcache2/go/1.2.3/arch');
-    });
   });
 });

--- a/__tests__/setup-go.test.ts
+++ b/__tests__/setup-go.test.ts
@@ -11,11 +11,12 @@ import * as im from '../src/installer';
 import goJsonData from './data/golang-dl.json';
 import matchers from '../matchers.json';
 import goTestManifest from './data/versions-manifest.json';
-import {addExecutablesToCache, IGoVersionInfo} from '../src/installer';
 const matcherPattern = matchers.problemMatcher[0].pattern[0];
 const matcherRegExp = new RegExp(matcherPattern.regexp);
 const win32Join = path.win32.join;
 const posixJoin = path.posix.join;
+
+jest.setTimeout(10000);
 
 describe('setup-go', () => {
   let inputs = {} as any;

--- a/__tests__/setup-go.test.ts
+++ b/__tests__/setup-go.test.ts
@@ -962,7 +962,7 @@ use .
   describe('Windows performance workaround', () => {
     it('addExecutablesToCache should depends on env[RUNNER_TOOL_CACHE]', async () => {
       const statSpy = jest.spyOn(fs, 'statSync');
-      // @ts-ignore
+      // @ts-ignore - not implement unused methods
       statSpy.mockImplementation(() => ({
         isDirectory: () => true
       }));

--- a/__tests__/windows-performance.test.ts
+++ b/__tests__/windows-performance.test.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import * as io from '@actions/io';
 import {addExecutablesToCache, IGoVersionInfo} from '../src/installer';
+import path from 'path';
 
 describe('Windows performance workaround', () => {
   let mkdirSpy: jest.SpyInstance;
@@ -52,10 +53,14 @@ describe('Windows performance workaround', () => {
 
     process.env['RUNNER_TOOL_CACHE'] = '/faked-hostedtoolcache1';
     const cacheDir1 = await addExecutablesToCache('/qzx', info, 'arch');
-    expect(cacheDir1).toBe('/faked-hostedtoolcache1/go/1.2.3/arch');
+    expect(cacheDir1).toBe(
+      path.join('/', 'faked-hostedtoolcache1', 'go', '1.2.3', 'arch')
+    );
 
     process.env['RUNNER_TOOL_CACHE'] = '/faked-hostedtoolcache2';
     const cacheDir2 = await addExecutablesToCache('/qzx', info, 'arch');
-    expect(cacheDir2).toBe('/faked-hostedtoolcache2/go/1.2.3/arch');
+    expect(cacheDir2).toBe(
+      path.join('/', 'faked-hostedtoolcache2', 'go', '1.2.3', 'arch')
+    );
   });
 });

--- a/__tests__/windows-performance.test.ts
+++ b/__tests__/windows-performance.test.ts
@@ -1,0 +1,61 @@
+import fs from 'fs';
+import * as io from '@actions/io';
+import {addExecutablesToCache, IGoVersionInfo} from '../src/installer';
+
+describe('Windows performance workaround', () => {
+  let mkdirSpy: jest.SpyInstance;
+  let symlinkSpy: jest.SpyInstance;
+  let statSpy: jest.SpyInstance;
+  let readdirSpy: jest.SpyInstance;
+  let writeFileSpy: jest.SpyInstance;
+  let rmRFSpy: jest.SpyInstance;
+  let mkdirPSpy: jest.SpyInstance;
+  let cpSpy: jest.SpyInstance;
+
+  let runnerToolCache: string | undefined;
+  beforeEach(() => {
+    mkdirSpy = jest.spyOn(fs, 'mkdir');
+    symlinkSpy = jest.spyOn(fs, 'symlinkSync');
+    statSpy = jest.spyOn(fs, 'statSync');
+    readdirSpy = jest.spyOn(fs, 'readdirSync');
+    writeFileSpy = jest.spyOn(fs, 'writeFileSync');
+    rmRFSpy = jest.spyOn(io, 'rmRF');
+    mkdirPSpy = jest.spyOn(io, 'mkdirP');
+    cpSpy = jest.spyOn(io, 'cp');
+
+    // default implementations
+    // @ts-ignore - not implement unused methods
+    statSpy.mockImplementation(() => ({
+      isDirectory: () => true
+    }));
+    readdirSpy.mockImplementation(() => []);
+    writeFileSpy.mockImplementation(() => {});
+    mkdirSpy.mockImplementation(() => {});
+    symlinkSpy.mockImplementation(() => {});
+    rmRFSpy.mockImplementation(() => Promise.resolve());
+    mkdirPSpy.mockImplementation(() => Promise.resolve());
+    cpSpy.mockImplementation(() => Promise.resolve());
+
+    runnerToolCache = process.env['RUNNER_TOOL_CACHE'];
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
+    process.env['RUNNER_TOOL_CACHE'] = runnerToolCache;
+  });
+  it('addExecutablesToCache should depend on env[RUNNER_TOOL_CACHE]', async () => {
+    const info: IGoVersionInfo = {
+      type: 'dist',
+      downloadUrl: 'http://nowhere.com',
+      resolvedVersion: '1.2.3',
+      fileName: 'ignore'
+    };
+
+    process.env['RUNNER_TOOL_CACHE'] = '/faked-hostedtoolcache1';
+    const cacheDir1 = await addExecutablesToCache('/qzx', info, 'arch');
+    expect(cacheDir1).toBe('/faked-hostedtoolcache1/go/1.2.3/arch');
+
+    process.env['RUNNER_TOOL_CACHE'] = '/faked-hostedtoolcache2';
+    const cacheDir2 = await addExecutablesToCache('/qzx', info, 'arch');
+    expect(cacheDir2).toBe('/faked-hostedtoolcache2/go/1.2.3/arch');
+  });
+});

--- a/__tests__/windows-performance.test.ts
+++ b/__tests__/windows-performance.test.ts
@@ -43,6 +43,9 @@ describe('Windows performance workaround', () => {
     jest.clearAllMocks();
     process.env['RUNNER_TOOL_CACHE'] = runnerToolCache;
   });
+  // addExecutablesToCache uses 3rd party dependency toolkit.cache under the hood
+  // that currently is implemented with RUNNER_TOOL_CACHE environment variable
+  // Make sure the implementation has not been changed
   it('addExecutablesToCache should depend on env[RUNNER_TOOL_CACHE]', async () => {
     const info: IGoVersionInfo = {
       type: 'dist',

--- a/__tests__/windows-toolcache.test.ts
+++ b/__tests__/windows-toolcache.test.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import * as io from '@actions/io';
-import {addExecutablesToCache, IGoVersionInfo} from '../src/installer';
+import * as tc from '@actions/tool-cache';
 import path from 'path';
 
 describe('Windows performance workaround', () => {
@@ -43,25 +43,18 @@ describe('Windows performance workaround', () => {
     jest.clearAllMocks();
     process.env['RUNNER_TOOL_CACHE'] = runnerToolCache;
   });
-  // addExecutablesToCache uses 3rd party dependency toolkit.cache under the hood
-  // that currently is implemented with RUNNER_TOOL_CACHE environment variable
+  // cacheWindowsToolkitDir depends on implementation of tc.cacheDir
+  // with the assumption that target dir is passed by RUNNER_TOOL_CACHE environment variable
   // Make sure the implementation has not been changed
   it('addExecutablesToCache should depend on env[RUNNER_TOOL_CACHE]', async () => {
-    const info: IGoVersionInfo = {
-      type: 'dist',
-      downloadUrl: 'http://nowhere.com',
-      resolvedVersion: '1.2.3',
-      fileName: 'ignore'
-    };
-
     process.env['RUNNER_TOOL_CACHE'] = '/faked-hostedtoolcache1';
-    const cacheDir1 = await addExecutablesToCache('/qzx', info, 'arch');
+    const cacheDir1 = await tc.cacheDir('/qzx', 'go', '1.2.3', 'arch');
     expect(cacheDir1).toBe(
       path.join('/', 'faked-hostedtoolcache1', 'go', '1.2.3', 'arch')
     );
 
     process.env['RUNNER_TOOL_CACHE'] = '/faked-hostedtoolcache2';
-    const cacheDir2 = await addExecutablesToCache('/qzx', info, 'arch');
+    const cacheDir2 = await tc.cacheDir('/qzx', 'go', '1.2.3', 'arch');
     expect(cacheDir2).toBe(
       path.join('/', 'faked-hostedtoolcache2', 'go', '1.2.3', 'arch')
     );

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -61468,8 +61468,12 @@ function installGoVersion(info, auth, arch) {
         // by avoiding write operations to C:
         const isHosted = process.env['RUNNER_ENVIRONMENT'] === 'github-hosted' ||
             process.env['AGENT_ISSELFHOSTED'] === '0';
-        if (isWindows && isHosted && fs_1.default.existsSync('d:\\') && fs_1.default.existsSync('c:\\')) {
-            const defaultToolCacheRoot = process.env['RUNNER_TOOL_CACHE'] || '';
+        const defaultToolCacheRoot = process.env['RUNNER_TOOL_CACHE'];
+        if (isWindows &&
+            defaultToolCacheRoot &&
+            isHosted &&
+            fs_1.default.existsSync('d:\\') &&
+            fs_1.default.existsSync('c:\\')) {
             const substitutedToolCacheRoot = defaultToolCacheRoot
                 .replace('C:', 'D:')
                 .replace('c:', 'd:');
@@ -61477,14 +61481,14 @@ function installGoVersion(info, auth, arch) {
             process.env['RUNNER_TOOL_CACHE'] = substitutedToolCacheRoot;
             const actualToolCacheDir = yield addExecutablesToCache(extPath, info, arch);
             // create a link from c: to d:
-            const lnkSrc = actualToolCacheDir.replace(substitutedToolCacheRoot, defaultToolCacheRoot);
-            fs_1.default.mkdirSync(path.dirname(lnkSrc), { recursive: true });
-            fs_1.default.symlinkSync(actualToolCacheDir, lnkSrc, 'junction');
-            core.info(`Created link ${lnkSrc} => ${actualToolCacheDir}`);
+            const defaultToolCacheDir = actualToolCacheDir.replace(substitutedToolCacheRoot, defaultToolCacheRoot);
+            fs_1.default.mkdirSync(path.dirname(defaultToolCacheDir), { recursive: true });
+            fs_1.default.symlinkSync(actualToolCacheDir, defaultToolCacheDir, 'junction');
+            core.info(`Created link ${defaultToolCacheDir} => ${actualToolCacheDir}`);
             // restore toolcache root to default drive c:
             process.env['RUNNER_TOOL_CACHE'] = defaultToolCacheRoot;
             // make outer code to continue using toolcache as if it were installed on c:
-            return lnkSrc;
+            return defaultToolCacheDir;
         }
         return yield addExecutablesToCache(extPath, info, arch);
     });

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -61464,7 +61464,10 @@ function installGoVersion(info, auth, arch) {
         if (info.type === 'dist') {
             extPath = path.join(extPath, 'go');
         }
-        if (isWindows) {
+        // for github hosted windows runner handle latency of OS drive
+        // by avoiding write operations to C:
+        const isHosted = (process.env['RUNNER_ENVIRONMENT'] = 'github-hosted');
+        if (isWindows && isHosted) {
             const defaultToolCacheRoot = process.env['RUNNER_TOOL_CACHE'] || '';
             const substitutedToolCacheRoot = defaultToolCacheRoot
                 .replace('C:', 'D:')

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -61338,7 +61338,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.resolveStableVersionInput = exports.parseGoVersionFile = exports.makeSemver = exports.getVersionsDist = exports.findMatch = exports.getInfoFromManifest = exports.getManifest = exports.extractGoArchive = exports.addExecutablesToCache = exports.getGo = void 0;
+exports.resolveStableVersionInput = exports.parseGoVersionFile = exports.makeSemver = exports.getVersionsDist = exports.findMatch = exports.getInfoFromManifest = exports.getManifest = exports.extractGoArchive = exports.getGo = void 0;
 const tc = __importStar(__nccwpck_require__(7784));
 const core = __importStar(__nccwpck_require__(2186));
 const path = __importStar(__nccwpck_require__(1017));
@@ -61441,15 +61441,46 @@ function resolveVersionFromManifest(versionSpec, stable, auth, arch, manifest) {
         }
     });
 }
-function addExecutablesToCache(extPath, info, arch) {
+// for github hosted windows runner handle latency of OS drive
+// by avoiding write operations to C:
+function cacheWindowsDir(extPath, tool, version, arch) {
     return __awaiter(this, void 0, void 0, function* () {
-        core.info('Adding to the cache ...');
-        const cachedDir = yield tc.cacheDir(extPath, 'go', makeSemver(info.resolvedVersion), arch);
-        core.info(`Successfully cached go to ${cachedDir}`);
-        return cachedDir;
+        if (os_1.default.platform() !== 'win32')
+            return false;
+        const isHosted = process.env['RUNNER_ENVIRONMENT'] === 'github-hosted' ||
+            process.env['AGENT_ISSELFHOSTED'] === '0';
+        if (!isHosted)
+            return false;
+        const defaultToolCacheRoot = process.env['RUNNER_TOOL_CACHE'];
+        if (!defaultToolCacheRoot)
+            return false;
+        if (!fs_1.default.existsSync('d:\\') || !fs_1.default.existsSync('c:\\'))
+            return false;
+        const actualToolCacheRoot = defaultToolCacheRoot
+            .replace('C:', 'D:')
+            .replace('c:', 'd:');
+        // make toolcache root to be on drive d:
+        process.env['RUNNER_TOOL_CACHE'] = actualToolCacheRoot;
+        const actualToolCacheDir = yield tc.cacheDir(extPath, tool, version, arch);
+        // create a link from c: to d:
+        const defaultToolCacheDir = actualToolCacheDir.replace(actualToolCacheRoot, defaultToolCacheRoot);
+        fs_1.default.mkdirSync(path.dirname(defaultToolCacheDir), { recursive: true });
+        fs_1.default.symlinkSync(actualToolCacheDir, defaultToolCacheDir, 'junction');
+        core.info(`Created link ${defaultToolCacheDir} => ${actualToolCacheDir}`);
+        // make outer code to continue using toolcache as if it were installed on c:
+        // restore toolcache root to default drive c:
+        process.env['RUNNER_TOOL_CACHE'] = defaultToolCacheRoot;
+        return defaultToolCacheDir;
     });
 }
-exports.addExecutablesToCache = addExecutablesToCache;
+function addExecutablesToToolCache(extPath, info, arch) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const tool = 'go';
+        const version = makeSemver(info.resolvedVersion);
+        return ((yield cacheWindowsDir(extPath, tool, version, arch)) ||
+            (yield tc.cacheDir(extPath, tool, version, arch)));
+    });
+}
 function installGoVersion(info, auth, arch) {
     return __awaiter(this, void 0, void 0, function* () {
         core.info(`Acquiring ${info.resolvedVersion} from ${info.downloadUrl}`);
@@ -61464,34 +61495,10 @@ function installGoVersion(info, auth, arch) {
         if (info.type === 'dist') {
             extPath = path.join(extPath, 'go');
         }
-        // for github hosted windows runner handle latency of OS drive
-        // by avoiding write operations to C:
-        if (!isWindows)
-            return addExecutablesToCache(extPath, info, arch);
-        const isHosted = process.env['RUNNER_ENVIRONMENT'] === 'github-hosted' ||
-            process.env['AGENT_ISSELFHOSTED'] === '0';
-        if (!isHosted)
-            return addExecutablesToCache(extPath, info, arch);
-        const defaultToolCacheRoot = process.env['RUNNER_TOOL_CACHE'];
-        if (!defaultToolCacheRoot)
-            return addExecutablesToCache(extPath, info, arch);
-        if (!fs_1.default.existsSync('d:\\') || !fs_1.default.existsSync('c:\\'))
-            return addExecutablesToCache(extPath, info, arch);
-        const substitutedToolCacheRoot = defaultToolCacheRoot
-            .replace('C:', 'D:')
-            .replace('c:', 'd:');
-        // make toolcache root to be on drive d:
-        process.env['RUNNER_TOOL_CACHE'] = substitutedToolCacheRoot;
-        const actualToolCacheDir = yield addExecutablesToCache(extPath, info, arch);
-        // create a link from c: to d:
-        const defaultToolCacheDir = actualToolCacheDir.replace(substitutedToolCacheRoot, defaultToolCacheRoot);
-        fs_1.default.mkdirSync(path.dirname(defaultToolCacheDir), { recursive: true });
-        fs_1.default.symlinkSync(actualToolCacheDir, defaultToolCacheDir, 'junction');
-        core.info(`Created link ${defaultToolCacheDir} => ${actualToolCacheDir}`);
-        // restore toolcache root to default drive c:
-        process.env['RUNNER_TOOL_CACHE'] = defaultToolCacheRoot;
-        // make outer code to continue using toolcache as if it were installed on c:
-        return defaultToolCacheDir;
+        core.info('Adding to the cache ...');
+        const toolCacheDir = yield addExecutablesToToolCache(extPath, info, arch);
+        core.info(`Successfully cached go to ${toolCacheDir}`);
+        return toolCacheDir;
     });
 }
 function extractGoArchive(archivePath) {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -61466,8 +61466,8 @@ function installGoVersion(info, auth, arch) {
         }
         // for github hosted windows runner handle latency of OS drive
         // by avoiding write operations to C:
-        const isHosted = (process.env['RUNNER_ENVIRONMENT'] = 'github-hosted');
-        if (isWindows && isHosted) {
+        const isHosted = process.env['RUNNER_ENVIRONMENT'] === 'github-hosted';
+        if (isWindows && isHosted && fs_1.default.existsSync('d:\\') && fs_1.default.existsSync('c:\\')) {
             const defaultToolCacheRoot = process.env['RUNNER_TOOL_CACHE'] || '';
             const substitutedToolCacheRoot = defaultToolCacheRoot
                 .replace('C:', 'D:')

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -61466,7 +61466,8 @@ function installGoVersion(info, auth, arch) {
         }
         // for github hosted windows runner handle latency of OS drive
         // by avoiding write operations to C:
-        const isHosted = process.env['RUNNER_ENVIRONMENT'] === 'github-hosted';
+        const isHosted = process.env['RUNNER_ENVIRONMENT'] === 'github-hosted' ||
+            process.env['AGENT_ISSELFHOSTED'] === '0';
         if (isWindows && isHosted && fs_1.default.existsSync('d:\\') && fs_1.default.existsSync('c:\\')) {
             const defaultToolCacheRoot = process.env['RUNNER_TOOL_CACHE'] || '';
             const substitutedToolCacheRoot = defaultToolCacheRoot

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -61447,9 +61447,9 @@ function cacheWindowsDir(extPath, tool, version, arch) {
     return __awaiter(this, void 0, void 0, function* () {
         if (os_1.default.platform() !== 'win32')
             return false;
-        const isHosted = process.env['RUNNER_ENVIRONMENT'] === 'github-hosted' ||
-            process.env['AGENT_ISSELFHOSTED'] === '0';
-        if (!isHosted)
+        // make sure the action runs in the hosted environment
+        if (process.env['RUNNER_ENVIRONMENT'] !== 'github-hosted' &&
+            process.env['AGENT_ISSELFHOSTED'] === '1')
             return false;
         const defaultToolCacheRoot = process.env['RUNNER_TOOL_CACHE'];
         if (!defaultToolCacheRoot)

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -203,7 +203,9 @@ async function installGoVersion(
 
   // for github hosted windows runner handle latency of OS drive
   // by avoiding write operations to C:
-  const isHosted = process.env['RUNNER_ENVIRONMENT'] === 'github-hosted';
+  const isHosted =
+    process.env['RUNNER_ENVIRONMENT'] === 'github-hosted' ||
+    process.env['AGENT_ISSELFHOSTED'] === '0';
   if (isWindows && isHosted && fs.existsSync('d:\\') && fs.existsSync('c:\\')) {
     const defaultToolCacheRoot = process.env['RUNNER_TOOL_CACHE'] || '';
     const substitutedToolCacheRoot = defaultToolCacheRoot

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -164,7 +164,7 @@ async function resolveVersionFromManifest(
   }
 }
 
-async function addExecutablesToCache(
+export async function addExecutablesToCache(
   extPath: string,
   info: IGoVersionInfo,
   arch: string

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -174,10 +174,12 @@ async function cacheWindowsDir(
 ): Promise<string | false> {
   if (os.platform() !== 'win32') return false;
 
-  const isHosted =
-    process.env['RUNNER_ENVIRONMENT'] === 'github-hosted' ||
-    process.env['AGENT_ISSELFHOSTED'] === '0';
-  if (!isHosted) return false;
+  // make sure the action runs in the hosted environment
+  if (
+    process.env['RUNNER_ENVIRONMENT'] !== 'github-hosted' &&
+    process.env['AGENT_ISSELFHOSTED'] === '1'
+  )
+    return false;
 
   const defaultToolCacheRoot = process.env['RUNNER_TOOL_CACHE'];
   if (!defaultToolCacheRoot) return false;

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -189,6 +189,7 @@ async function installGoVersion(
 
   // Windows requires that we keep the extension (.zip) for extraction
   const isWindows = os.platform() === 'win32';
+
   const tempDir = process.env.RUNNER_TEMP || '.';
   const fileName = isWindows ? path.join(tempDir, info.fileName) : undefined;
 
@@ -201,7 +202,10 @@ async function installGoVersion(
     extPath = path.join(extPath, 'go');
   }
 
-  if (isWindows) {
+  // for github hosted windows runner handle latency of OS drive
+  // by avoiding write operations to C:
+  const isHosted = (process.env['RUNNER_ENVIRONMENT'] = 'github-hosted');
+  if (isWindows && isHosted) {
     const defaultToolCacheRoot = process.env['RUNNER_TOOL_CACHE'] || '';
     const substitutedToolCacheRoot = defaultToolCacheRoot
       .replace('C:', 'D:')

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -189,7 +189,6 @@ async function installGoVersion(
 
   // Windows requires that we keep the extension (.zip) for extraction
   const isWindows = os.platform() === 'win32';
-
   const tempDir = process.env.RUNNER_TEMP || '.';
   const fileName = isWindows ? path.join(tempDir, info.fileName) : undefined;
 
@@ -204,8 +203,8 @@ async function installGoVersion(
 
   // for github hosted windows runner handle latency of OS drive
   // by avoiding write operations to C:
-  const isHosted = (process.env['RUNNER_ENVIRONMENT'] = 'github-hosted');
-  if (isWindows && isHosted) {
+  const isHosted = process.env['RUNNER_ENVIRONMENT'] === 'github-hosted';
+  if (isWindows && isHosted && fs.existsSync('d:\\') && fs.existsSync('c:\\')) {
     const defaultToolCacheRoot = process.env['RUNNER_TOOL_CACHE'] || '';
     const substitutedToolCacheRoot = defaultToolCacheRoot
       .replace('C:', 'D:')


### PR DESCRIPTION
**Description:**

In order to avoid slow IO of C: drive the go executables are cached to D: drive instead of C: drive and create a link (junction) from an expected location (c:\hostedtoolcache) to the actual  (D:\hostedtoolcache). 

**Related issue:**
[Original issue](https://github.com/actions/setup-go/issues/240)
[Investigation issue](https://github.com/actions/runner-images-internal/discussions/5143)

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.