### PR TITLE
chore: update to use go1.21

### DIFF
--- a/.github/workflows/windows-validation.yml
+++ b/.github/workflows/windows-validation.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         cache: [false, true]
-        go: [1.20.1]
+        go: [1.21.1]
     steps:
       - uses: actions/checkout@v4
 
@@ -119,7 +119,7 @@ jobs:
     strategy:
       matrix:
         cache: [false]
-        go: [1.20.1]
+        go: [1.21.1]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
**Description:**
With go1.21 release, bump the golang usage/docs to it

**Related issue:**
n/a

**Check list:**
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.