### PR TITLE
Set default `cache` input to false for self-hosted runners

### DIFF
--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -58495,6 +58495,7 @@ const cache = __importStar(__nccwpck_require__(7799));
 const fs_1 = __importDefault(__nccwpck_require__(7147));
 const constants_1 = __nccwpck_require__(9042);
 const cache_utils_1 = __nccwpck_require__(1678);
+const utils_1 = __nccwpck_require__(1314);
 // Catch and log any unhandled exceptions.  These exceptions can leak out of the uploadChunk method in
 // @actions/toolkit when a failed upload closes the file descriptor causing any in-process reads to
 // throw an uncaught exception.  Instead of failing this action, just warn.
@@ -58521,10 +58522,8 @@ function run() {
 }
 exports.run = run;
 const cachePackages = () => __awaiter(void 0, void 0, void 0, function* () {
-    const cacheInput = core.getBooleanInput('cache');
-    if (!cacheInput) {
+    if (!utils_1.getCacheInput())
         return;
-    }
     const packageManager = 'default';
     const state = core.getState(constants_1.State.CacheMatchedKey);
     const primaryKey = core.getState(constants_1.State.CachePrimaryKey);
@@ -58691,6 +58690,52 @@ exports.supportedPackageManagers = {
         cacheFolderCommandList: ['go env GOMODCACHE', 'go env GOCACHE']
     }
 };
+
+
+/***/ }),
+
+/***/ 1314:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.getCacheInput = exports.isSelfHosted = exports.StableReleaseAlias = void 0;
+const core = __importStar(__nccwpck_require__(2186));
+var StableReleaseAlias;
+(function (StableReleaseAlias) {
+    StableReleaseAlias["Stable"] = "stable";
+    StableReleaseAlias["OldStable"] = "oldstable";
+})(StableReleaseAlias = exports.StableReleaseAlias || (exports.StableReleaseAlias = {}));
+const isSelfHosted = () => process.env['RUNNER_ENVIRONMENT'] !== 'github-hosted' &&
+    process.env['AGENT_ISSELFHOSTED'] === '1';
+exports.isSelfHosted = isSelfHosted;
+const getCacheInput = () => {
+    // for self-hosted environment turn off cache by default
+    if (exports.isSelfHosted() && core.getInput('cache') === '')
+        return false;
+    return core.getBooleanInput('cache');
+};
+exports.getCacheInput = getCacheInput;
 
 
 /***/ }),

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -61495,8 +61495,7 @@ function cacheWindowsDir(extPath, tool, version, arch) {
         if (os_1.default.platform() !== 'win32')
             return false;
         // make sure the action runs in the hosted environment
-        if (process.env['RUNNER_ENVIRONMENT'] !== 'github-hosted' &&
-            process.env['AGENT_ISSELFHOSTED'] === '1')
+        if (utils_1.isSelfHosted())
             return false;
         const defaultToolCacheRoot = process.env['RUNNER_TOOL_CACHE'];
         if (!defaultToolCacheRoot)
@@ -61777,6 +61776,7 @@ const cache_utils_1 = __nccwpck_require__(1678);
 const child_process_1 = __importDefault(__nccwpck_require__(2081));
 const fs_1 = __importDefault(__nccwpck_require__(7147));
 const os_1 = __importDefault(__nccwpck_require__(2037));
+const utils_1 = __nccwpck_require__(1314);
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
@@ -61785,7 +61785,7 @@ function run() {
             // If not supplied then problem matchers will still be setup.  Useful for self-hosted.
             //
             const versionSpec = resolveVersionInput();
-            const cache = core.getBooleanInput('cache');
+            const cache = utils_1.getCacheInput();
             core.info(`Setup go version spec ${versionSpec}`);
             let arch = core.getInput('architecture');
             if (!arch) {
@@ -61966,17 +61966,47 @@ exports.getArch = getArch;
 /***/ }),
 
 /***/ 1314:
-/***/ ((__unused_webpack_module, exports) => {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.StableReleaseAlias = void 0;
+exports.getCacheInput = exports.isSelfHosted = exports.StableReleaseAlias = void 0;
+const core = __importStar(__nccwpck_require__(2186));
 var StableReleaseAlias;
 (function (StableReleaseAlias) {
     StableReleaseAlias["Stable"] = "stable";
     StableReleaseAlias["OldStable"] = "oldstable";
 })(StableReleaseAlias = exports.StableReleaseAlias || (exports.StableReleaseAlias = {}));
+const isSelfHosted = () => process.env['RUNNER_ENVIRONMENT'] !== 'github-hosted' &&
+    process.env['AGENT_ISSELFHOSTED'] === '1';
+exports.isSelfHosted = isSelfHosted;
+const getCacheInput = () => {
+    // for self-hosted environment turn off cache by default
+    if (exports.isSelfHosted() && core.getInput('cache') === '')
+        return false;
+    return core.getBooleanInput('cache');
+};
+exports.getCacheInput = getCacheInput;
 
 
 /***/ }),

--- a/src/cache-save.ts
+++ b/src/cache-save.ts
@@ -3,6 +3,7 @@ import * as cache from '@actions/cache';
 import fs from 'fs';
 import {State} from './constants';
 import {getCacheDirectoryPath, getPackageManagerInfo} from './cache-utils';
+import {getCacheInput} from './utils';
 
 // Catch and log any unhandled exceptions.  These exceptions can leak out of the uploadChunk method in
 // @actions/toolkit when a failed upload closes the file descriptor causing any in-process reads to
@@ -28,10 +29,7 @@ export async function run() {
 }
 
 const cachePackages = async () => {
-  const cacheInput = core.getBooleanInput('cache');
-  if (!cacheInput) {
-    return;
-  }
+  if (!getCacheInput()) return;
 
   const packageManager = 'default';
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -6,7 +6,7 @@ import * as httpm from '@actions/http-client';
 import * as sys from './system';
 import fs from 'fs';
 import os from 'os';
-import {StableReleaseAlias} from './utils';
+import {isSelfHosted, StableReleaseAlias} from './utils';
 
 type InstallationType = 'dist' | 'manifest';
 
@@ -175,11 +175,7 @@ async function cacheWindowsDir(
   if (os.platform() !== 'win32') return false;
 
   // make sure the action runs in the hosted environment
-  if (
-    process.env['RUNNER_ENVIRONMENT'] !== 'github-hosted' &&
-    process.env['AGENT_ISSELFHOSTED'] === '1'
-  )
-    return false;
+  if (isSelfHosted()) return false;
 
   const defaultToolCacheRoot = process.env['RUNNER_TOOL_CACHE'];
   if (!defaultToolCacheRoot) return false;

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import {isCacheFeatureAvailable} from './cache-utils';
 import cp from 'child_process';
 import fs from 'fs';
 import os from 'os';
+import {getCacheInput} from './utils';
 
 export async function run() {
   try {
@@ -17,7 +18,7 @@ export async function run() {
     //
     const versionSpec = resolveVersionInput();
 
-    const cache = core.getBooleanInput('cache');
+    const cache = getCacheInput();
     core.info(`Setup go version spec ${versionSpec}`);
 
     let arch = core.getInput('architecture');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,17 @@
+import * as core from '@actions/core';
+
 export enum StableReleaseAlias {
   Stable = 'stable',
   OldStable = 'oldstable'
 }
+
+export const isSelfHosted = (): boolean =>
+  process.env['RUNNER_ENVIRONMENT'] !== 'github-hosted' &&
+  process.env['AGENT_ISSELFHOSTED'] === '1';
+
+export const getCacheInput = (): boolean => {
+  // for self-hosted environment turn off cache by default
+  if (isSelfHosted() && core.getInput('cache') === '') return false;
+
+  return core.getBooleanInput('cache');
+};


### PR DESCRIPTION
**Description:**
Wrap `core.getBooleanInptu('cache')` in order to force default value to false if action runs in self-hosted environment

**Related issue:**
https://github.com/actions/setup-go/issues/403


**Check list:**
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.