### PR TITLE
 Improve documentation regarding dependencies caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ The `cache` input is optional, and caching is turned on by default.
 
 The action defaults to search for the dependency file - go.sum in the repository root, and uses its hash as a part of
 the cache key. Use `cache-dependency-path` input for cases when multiple dependency files are used, or they are located
-in different subdirectories. Wildcards also supported.
+in different subdirectories. Globs also supported.
 
 If some problem that prevents success caching happens then the action issues the warning in the log and continues the execution of the pipeline. 
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ The `cache` input is optional, and caching is turned on by default.
 
 The action defaults to search for the dependency file - go.sum in the repository root, and uses its hash as a part of
 the cache key. Use `cache-dependency-path` input for cases when multiple dependency files are used, or they are located
-in different subdirectories. Globs also supported.
+in different subdirectories. The input supports glob patterns.
 
 If some problem that prevents success caching happens then the action issues the warning in the log and continues the execution of the pipeline. 
 


### PR DESCRIPTION
**Description:**
Just a highlighting that `cache-dependency-path` parameter can accept multiple files and can handle wildcards + example.

**Related issue:**
https://github.com/actions/setup-go/issues/371

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.