### PR TITLE
feat: upgrade to use node 20 runtime and bump checkout action to v4

### DIFF
--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Go Stable
         uses: ./
         with:
@@ -35,7 +35,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Go oldStable
         uses: ./
         with:
@@ -55,7 +55,7 @@ jobs:
           - os: macos-latest
             architecture: x32
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Go ${{ matrix.version }} ${{ matrix.architecture }}
         uses: ./
         with:
@@ -74,7 +74,7 @@ jobs:
         go: [1.17, 1.18, 1.19]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: setup-go ${{ matrix.go }}
         uses: ./
@@ -93,7 +93,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         go-version: [1.16, 1.17]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Go and check latest
         uses: ./
         with:
@@ -109,7 +109,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Go and check latest
         uses: ./
         with:
@@ -125,7 +125,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Go and check latest
         uses: ./
         with:
@@ -144,7 +144,7 @@ jobs:
         go: [1.12.16, 1.13.11, 1.14.3]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: setup-go ${{ matrix.go }}
         uses: ./
@@ -165,7 +165,7 @@ jobs:
         go: [1.9, 1.8.6]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: setup-go ${{ matrix.go }}
         uses: ./
@@ -184,7 +184,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         go-version: [1.16, 1.17]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Go and check latest
         uses: ./
         with:

--- a/.github/workflows/windows-validation.yml
+++ b/.github/workflows/windows-validation.yml
@@ -19,7 +19,7 @@ jobs:
         cache: [false, true]
         go: [1.20.1]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: 'Setup ${{ matrix.cache }}, cache: ${{ matrix.go }}'
         uses: ./
@@ -61,7 +61,7 @@ jobs:
             echo 'which go should return "/c/hostedtoolcache/windows/go/${{ matrix.go }}/x64/bin/go"'
             exit 1
           fi
-          if [ $(go env GOROOT) != 'C:\hostedtoolcache\windows\go\${{ matrix.go }}\x64' ];then 
+          if [ $(go env GOROOT) != 'C:\hostedtoolcache\windows\go\${{ matrix.go }}\x64' ];then
             echo 'go env GOROOT should return "C:\hostedtoolcache\windows\go\${{ matrix.go }}\x64"'
             exit 1
           fi
@@ -88,7 +88,7 @@ jobs:
       matrix:
         cache: [false, true]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: 'Setup default go, cache: ${{ matrix.cache }}'
         uses: ./
@@ -121,7 +121,7 @@ jobs:
         cache: [false]
         go: [1.20.1]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: 'Setup ${{ matrix.go }}, cache: ${{ matrix.cache }}'
         uses: ./

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Matching by [semver spec](https://github.com/npm/node-semver):
 
 ```yaml
 steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
   - uses: actions/setup-go@v4
     with:
       go-version: '^1.13.1' # The Go version to download (if necessary) and use.
@@ -51,7 +51,7 @@ steps:
 
 ```yaml
 steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
   - uses: actions/setup-go@v4
     with:
       go-version: '>=1.17.0'
@@ -59,17 +59,17 @@ steps:
 ```
 
 > **Note**: Due to the peculiarities of YAML parsing, it is recommended to wrap the version in single quotation marks:
-> 
+>
 > ```yaml
 >   go-version: '1.20'
 >  ```
->  
+>
 > The recommendation is based on the YAML parser's behavior, which interprets non-wrapped values as numbers and, in the case of version 1.20, trims it down to 1.2, which may not be very obvious.
 Matching an unstable pre-release:
 
 ```yaml
 steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
   - uses: actions/setup-go@v4
     with:
       go-version: '1.18.0-rc.1' # The Go version to download (if necessary) and use.
@@ -78,7 +78,7 @@ steps:
 
 ```yaml
 steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
   - uses: actions/setup-go@v4
     with:
       go-version: '1.16.0-beta.1' # The Go version to download (if necessary) and use.
@@ -93,7 +93,7 @@ See [action.yml](action.yml)
 
 ```yaml
 steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
   - uses: actions/setup-go@v4
     with:
       go-version: '1.16.1' # The Go version to download (if necessary) and use.
@@ -114,7 +114,7 @@ want the most up-to-date Go version to always be used.
 
 ```yaml
 steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
   - uses: actions/setup-go@v4
     with:
       go-version: '1.14'
@@ -135,7 +135,7 @@ set to `true`
 
 ```yaml
 steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
   - uses: actions/setup-go@v4
     with:
       go-version: 'stable'
@@ -144,7 +144,7 @@ steps:
 
 ```yaml
 steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
   - uses: actions/setup-go@v4
     with:
       go-version: 'oldstable'
@@ -161,20 +161,20 @@ The action defaults to search for the dependency file - go.sum in the repository
 the cache key. Use `cache-dependency-path` input for cases when multiple dependency files are used, or they are located
 in different subdirectories. The input supports glob patterns.
 
-If some problem that prevents success caching happens then the action issues the warning in the log and continues the execution of the pipeline. 
+If some problem that prevents success caching happens then the action issues the warning in the log and continues the execution of the pipeline.
 
 **Caching in monorepos**
 
 ```yaml
 steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
   - uses: actions/setup-go@v4
     with:
       go-version: '1.17'
       check-latest: true
       cache-dependency-path: |
-             subdir/go.sum 
-             tools/go.sum   
+             subdir/go.sum
+             tools/go.sum
     # cache-dependency-path: "**/*.sum"
 
   - run: go run hello.go
@@ -193,7 +193,7 @@ If both the `go-version` and the `go-version-file` inputs are provided then the 
 
 ```yaml
 steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
   - uses: actions/setup-go@v4
     with:
       go-version-file: 'path/to/go.mod'
@@ -211,7 +211,7 @@ jobs:
         go: [ '1.14', '1.13' ]
     name: Go ${{ matrix.go }} sample
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup go
         uses: actions/setup-go@v4
         with:

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ outputs:
   cache-hit:
     description: 'A boolean value to indicate if a cache was hit'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/setup/index.js'
   post: 'dist/cache-save/index.js'
   post-if: success()

--- a/docs/adrs/0000-caching-dependencies.md
+++ b/docs/adrs/0000-caching-dependencies.md
@@ -4,7 +4,7 @@ Date: 2022-04-13
 Status: Accepted
 
 # Context
-`actions/setup-go` is the one of the most popular action related to Golang in GitHub Actions. Many customers use it in conjunction with [actions/cache](https://github.com/actions/cache) to speed up dependency installation process.  
+`actions/setup-go` is the one of the most popular action related to Golang in GitHub Actions. Many customers use it in conjunction with [actions/cache](https://github.com/actions/cache) to speed up dependency installation process.
 See more examples on proper usage in [actions/cache documentation](https://github.com/actions/cache/blob/main/examples.md#go---modules).
 
 # Goals & Anti-Goals
@@ -16,7 +16,7 @@ Integration of caching functionality into `actions/setup-go` action will bring t
 We don't pursue the goal to provide wide customization of caching in scope of `actions/setup-go` action. The purpose of this integration is covering ~90% of basic use-cases. If user needs flexible customization, we should advice them to use `actions/cache` directly.
 
 # Decision
-- Add `cache` input parameter to `actions/setup-go`. For now, input will accept the following values: 
+- Add `cache` input parameter to `actions/setup-go`. For now, input will accept the following values:
   - `true` - enable caching for go dependencies
   - `false`- disable caching for go dependencies. This value will be set as default value
 - Cache feature will be disabled by default to make sure that we don't break existing customers. We will consider enabling cache by default in next major releases
@@ -32,7 +32,7 @@ We don't pursue the goal to provide wide customization of caching in scope of `a
 
 ```yml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-go@v3
   with:
     go-version: '18'
@@ -43,7 +43,7 @@ steps:
 
  ```yml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-go@v3
   with:
     go-version: '18'
@@ -53,7 +53,7 @@ steps:
 
  ```yml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-go@v3
   with:
     go-version: '18'


### PR DESCRIPTION
**Description:**

Node12 was deleted from runner. Node20 was added to Actions Runner on v2.308.0.
Node16 has en end of life on 11 Sep 2023.

This PR updates the default runtime to node20, rather then node16

relates to https://github.com/actions/runner/pull/2732

**Related issue:**
N/A

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.

---

needs a major version bump after the PR merge