### PR TITLE
Add ppc64le support

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -61948,13 +61948,19 @@ function getArch(arch) {
     // 'arm', 'arm64', 'ia32', 'mips', 'mipsel', 'ppc', 'ppc64', 's390', 's390x', 'x32', and 'x64'.
     // wants amd64, 386, arm64, armv61, ppc641e, s390x
     // currently not supported by runner but future proofed mapping
+    let endianness = os_1.default.endianness();
     switch (arch) {
         case 'x64':
             arch = 'amd64';
             break;
-        // case 'ppc':
-        //   arch = 'ppc64';
-        //   break;
+        case 'ppc64':
+            if(endianness=='LE') {
+              arch = 'ppc64le';
+            }
+            else {
+              arch = 'ppc64';
+            }
+            break;
         case 'x32':
             arch = '386';
             break;

--- a/src/system.ts
+++ b/src/system.ts
@@ -20,13 +20,19 @@ export function getArch(arch: string): string {
 
   // wants amd64, 386, arm64, armv61, ppc641e, s390x
   // currently not supported by runner but future proofed mapping
+  let endianness: string = os.endianness();
   switch (arch) {
     case 'x64':
       arch = 'amd64';
       break;
-    // case 'ppc':
-    //   arch = 'ppc64';
-    //   break;
+    case 'ppc64':
+      if(endianness=='LE') {
+       arch = 'ppc64le';
+      }
+      else {
+       arch = 'ppc64';
+      }
+      break;
     case 'x32':
       arch = '386';
       break;


### PR DESCRIPTION
**Description:**
This PR will add support for ppc64le architecture. Official [Go](https://go.dev/dl/) binaries are published for linux-ppc64, linux-ppc64le and aix-ppc64 variants. All these variants are being taken care of in the changes.

**Related issue:**
NA

**Check list:**
- [X] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.