### PR TITLE
Remove the description of the old go.mod specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,12 @@ steps:
 
 The `go-version-file` input accepts a path to a `go.mod` file or a `go.work` file that contains the version of Go to be used by a project.
 
+The `go` directive in `go.mod` can specify a patch version or omit it altogether (e.g., `go 1.22.0` or `go 1.22`).  
+If a patch version is specified, that specific patch version will be used.  
+If no patch version is specified, it will search for the latest available patch version in the cache,
+[versions-manifest.json](https://github.com/actions/go-versions/blob/main/versions-manifest.json), and the
+[official Go language website](https://golang.org/dl/?mode=json&include=all), in that order.
+
 If both the `go-version` and the `go-version-file` inputs are provided then the `go-version` input is used.
 > The action will search for the `go.mod` file relative to the repository root
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ steps:
   - uses: actions/checkout@v4
   - uses: actions/setup-go@v5
     with:
-      go-version-file: path/to/go.mod
+      go-version-file: 'path/to/go.mod'
   - run: go version
 ```
 

--- a/README.md
+++ b/README.md
@@ -183,8 +183,7 @@ steps:
 
 ## Getting go version from the go.mod file
 
-The `go-version-file` input accepts a path to a `go.mod` file or a `go.work` file that contains the version of Go to be
-used by a project.
+The `go-version-file` input accepts a path to a `go.mod` file or a `go.work` file that contains the version of Go to be used by a project.
 
 If both the `go-version` and the `go-version-file` inputs are provided then the `go-version` input is used.
 > The action will search for the `go.mod` file relative to the repository root

--- a/README.md
+++ b/README.md
@@ -184,10 +184,7 @@ steps:
 ## Getting go version from the go.mod file
 
 The `go-version-file` input accepts a path to a `go.mod` file or a `go.work` file that contains the version of Go to be
-used by a project. As the `go.mod` file contains only major and minor (e.g. 1.18) tags, the action will search for the
-latest available patch version sequentially in the runner's directory with the cached tools, in
-the [versions-manifest.json](https://github.com/actions/go-versions/blob/main/versions-manifest.json) file or at the go
-servers.
+used by a project.
 
 If both the `go-version` and the `go-version-file` inputs are provided then the `go-version` input is used.
 > The action will search for the `go.mod` file relative to the repository root

--- a/README.md
+++ b/README.md
@@ -62,9 +62,10 @@ steps:
 >
 > ```yaml
 >   go-version: '1.20'
->  ```
+> ```
 >
 > The recommendation is based on the YAML parser's behavior, which interprets non-wrapped values as numbers and, in the case of version 1.20, trims it down to 1.2, which may not be very obvious.
+
 Matching an unstable pre-release:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ steps:
   - uses: actions/checkout@v4
   - uses: actions/setup-go@v5
     with:
-      go-version-file: 'path/to/go.mod'
+      go-version-file: path/to/go.mod
   - run: go version
 ```
 

--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -6,13 +6,13 @@ We have prepared a short guide so that the process of making your contribution i
 
 ## How can I contribute...
 
-* [Contribute Documentation:green_book:](#contribute-documentation)
+* [Contribute Documentation :green_book:](#contribute-documentation)
 
 * [Contribute Code :computer:](#contribute-code)
 
-* [Provide Support on Issues:pencil:](#provide-support-on-issues)
+* [Provide Support on Issues :pencil:](#provide-support-on-issues)
 
-* [Review Pull Requests:mag:](#review-pull-requests)
+* [Review Pull Requests :mag:](#review-pull-requests)
 
 ## Contribute documentation
 


### PR DESCRIPTION
**Description:**

Starting from Go 1.21, the go.mod file now includes patch versions as well.

```
$ go1.21.0 mod init test
go: creating new go.mod: module test
$ cat go.mod
module test

go 1.21.0
```

This is explained in the official Go documentation.

> Go 1.21 introduces a small change to the numbering of releases. In the past, we used Go 1.N to refer to both the overall Go language version and release family as well as the first release in that family. Starting in Go 1.21, the first release is now Go 1.N.0. Today we are releasing both the Go 1.21 language and its initial implementation, the Go 1.21.0 release. These notes refer to “Go 1.21”; tools like go version will report “go1.21.0” (until you upgrade to Go 1.21.1). See “[Go versions](https://go.dev/doc/toolchain#version)” in the “Go Toolchains” documentation for details about the new version numbering.
> https://go.dev/doc/go1.21#introduction

setup-go retrieves the version of the go.mod file using the following code and can obtain the patch version as well.

https://github.com/actions/setup-go/blob/6c1fd22b67f7a7c42ad9a45c0f4197434035e429/src/installer.ts#L427

Test:

https://www.typescriptlang.org/play?#code/MYewdgzgLgBKZQKYIjAvDARAcxDAjAHQBMxhADJgNwBQ80MAtgIZTAAW6c4SKhLbdgAoA9AD1cMIQB0AJgGoZhOfICUAKlUjGq2vRAAbRIQMhsQgR10wYQA

Additionally, I fixed the following:

- Fix emoji rendering in `contributors.md`.
- Fix quoting in `README.md`.
- Remove the single quotes from `go-version-file`.

**Related issue:**

Fixes #461.

**Check list:**

- ~[ ] Mark if documentation changes are required.~
- ~[ ] Mark if tests were added or updated to cover the changes.~

This pull request is a documentation update itself. No testing is necessary.