### PR TITLE
Enhance workflows and Upgrade micromatch Dependency

### DIFF
--- a/.github/workflows/release-new-action-version.yml
+++ b/.github/workflows/release-new-action-version.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update the ${{ env.TAG_NAME }} tag
-        uses: actions/publish-action@v0.2.2
+        uses: actions/publish-action@v0.3.0
         with:
           source-tag: ${{ env.TAG_NAME }}
           slack-webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -73,7 +73,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest, macos-13]
-        go: [1.21.13, 1.22.7]
+        go: [1.21.13, 1.22.8, 1.23.2]
+        include:
+          - os: windows-latest
+            go: 1.20.14
+        exclude:
+          - os: windows-latest
+            go: 1.23.2
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -183,12 +189,21 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
         go-version: [1.20.14, 1.21, 1.22, 1.23]
+        include:
+          - os: macos-latest
+            architecture: arm64
+          - os: ubuntu-latest
+            architecture: x64
+          - os: windows-latest
+            architecture: x64
+          - os: macos-13
+            architecture: x64
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go and check latest
         uses: ./
         with:
           go-version: ${{ matrix.go-version }}
-          architecture: x64
+          architecture: ${{ matrix.architecture }}
       - name: Verify Go
         run: go version

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go Stable
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go oldStable
@@ -48,11 +48,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
         version: [stable, oldstable]
         architecture: [x64, x32]
         exclude:
           - os: macos-latest
+            architecture: x32
+          - os: macos-13
             architecture: x32
     steps:
       - uses: actions/checkout@v4
@@ -70,8 +72,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
-        go: [1.20.14, 1.21.10, 1.22.3]
+        os: [macos-latest, windows-latest, ubuntu-latest, macos-13]
+        go: [1.21.13, 1.22.7]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -90,7 +92,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
         go-version: [1.20.14, 1.21]
     steps:
       - uses: actions/checkout@v4
@@ -107,7 +109,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go and check latest
@@ -123,7 +125,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go and check latest
@@ -140,7 +142,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [macos-latest, windows-latest, ubuntu-latest, macos-13]
         go: [1.20.14, 1.21.10, 1.22.3]
     steps:
       - name: Checkout
@@ -161,7 +163,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [macos-latest, windows-latest, ubuntu-latest, macos-13]
         go: [1.20.14, 1.21]
     steps:
       - name: Checkout
@@ -181,7 +183,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
         go-version: [1.20.14, 1.21]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -93,7 +93,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
-        go-version: [1.20.14, 1.21]
+        go-version: ['1.20', '1.21', '1.22', '1.23']
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go and check latest
@@ -137,13 +137,12 @@ jobs:
         shell: bash
 
   setup-versions-from-manifest:
-    name: Setup ${{ matrix.go }} ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest, macos-13]
-        go: [1.20.14, 1.21.10, 1.22.3]
+        go: [1.20.14, 1.21.10, 1.22.8, 1.23.2]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -158,13 +157,12 @@ jobs:
         shell: bash
 
   setup-versions-from-dist:
-    name: Setup ${{ matrix.go }} ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest, macos-13]
-        go: [1.20.14, 1.21]
+        os: [windows-latest, ubuntu-latest, macos-13]
+        go: [1.11.12]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -184,7 +182,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
-        go-version: [1.20.14, 1.21]
+        go-version: [1.20.14, 1.21, 1.22, 1.23]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go and check latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -4559,12 +4559,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {


### PR DESCRIPTION
**Description:**

- Update the Validate 'setup-go' workflow to include macos-13 and refreshed local-cache versions to align with the latest platform capabilities and performance enhancements.

- Upgrade the actions/publish-action to version @v0.3.0

- Bump [micromatch](https://github.com/micromatch/micromatch) from 4.0.5 to 4.0.8

**Related issue:**
N/A

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.