### PR TITLE
Fix slow cache restore on Windows

### DIFF
--- a/.github/workflows/windows-validation.yml
+++ b/.github/workflows/windows-validation.yml
@@ -134,3 +134,40 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
           cache: ${{ matrix.cache }}
+
+  go-mod-cache-and-tmp-location:
+    name: 'Validate if GOCACHE, GOMODCACHE, GOTMPDIR is set to drive D:'
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        cache: [false]
+        go: [1.20.1]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: 'Setup ${{ matrix.go }}, cache: ${{ matrix.cache }}'
+        uses: ./
+        with:
+          go-version: ${{ matrix.go }}
+          cache: ${{ matrix.cache }}
+
+      - name: 'Check if go mod cache and tmp location is set correctly'
+        run: |
+          go env GOCACHE
+          go env GOMODCACHE
+          go env GOTMPDIR
+
+          if [ $(go env GOCACHE) != 'D:\Users\runneradmin\AppData\Local\go-build' ];then
+            echo 'go env GOCACHE should return "D:\Users\runneradmin\AppData\Local\go-build"'
+            exit 1
+          fi
+          if [ $(go env GOMODCACHE) != 'D:\Users\runneradmin\go\pkg\mod' ];then
+            echo 'go env GOMODCACHE should return "D:\Users\runneradmin\go\pkg\mod"'
+            exit 1
+          fi
+          if [ $(go env GOTMPDIR) != 'D:\gotmp' ];then
+            echo 'go env GOTMPDIR should return "D:\gotmp"'
+            exit 1
+          fi
+
+        shell: bash

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -88402,12 +88402,17 @@ function cacheWindowsDir(extPath, tool, version, arch) {
         for (const cachePath of actualCacheDirectoryPaths) {
             core.info(`Trying to link ${cachePath.defaultPath} to ${cachePath.actualPath}`);
             try {
+                if (!fs_1.default.existsSync(cachePath.defaultPath)) {
+                    core.info(`Default path ${cachePath.defaultPath} does not exist`);
+                    core.info(`Creating directory ${cachePath.defaultPath}`);
+                    fs_1.default.mkdirSync(cachePath.defaultPath, { recursive: true });
+                }
                 if (!fs_1.default.existsSync(cachePath.actualPath)) {
-                    core.info(`Creating directory ${cachePath.actualPath}`);
-                    fs_1.default.mkdirSync(path.dirname(cachePath.actualPath), { recursive: true });
+                    core.info(`Actual path ${cachePath.actualPath} does not exist. Safe to create symlink`);
                 }
                 else {
-                    core.info(`Directory ${cachePath.actualPath} already exists`);
+                    core.info(`Actual path ${cachePath.actualPath} already exists. Skipping symlink creation`);
+                    continue;
                 }
                 // check if the default path is a symlink
                 const isSymlink = fs_1.default.lstatSync(cachePath.defaultPath).isSymbolicLink();

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -88283,7 +88283,6 @@ const sys = __importStar(__nccwpck_require__(5632));
 const fs_1 = __importDefault(__nccwpck_require__(7147));
 const os_1 = __importDefault(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(1314);
-const cache_utils_1 = __nccwpck_require__(1678);
 function getGo(versionSpec_1, checkLatest_1, auth_1) {
     return __awaiter(this, arguments, void 0, function* (versionSpec, checkLatest, auth, arch = os_1.default.arch()) {
         var _a;
@@ -88408,53 +88407,6 @@ function cacheWindowsDir(extPath, tool, version, arch) {
         const defaultToolCacheCompleteFile = `${defaultToolCacheDir}.complete`;
         fs_1.default.symlinkSync(actualToolCacheCompleteFile, defaultToolCacheCompleteFile, 'file');
         core.info(`Created link ${defaultToolCacheCompleteFile} => ${actualToolCacheCompleteFile}`);
-        const packageManager = 'default';
-        const packageManagerInfo = yield (0, cache_utils_1.getPackageManagerInfo)(packageManager);
-        const cacheDirectoryPaths = yield (0, cache_utils_1.getCacheDirectoryPath)(packageManagerInfo);
-        if (!cacheDirectoryPaths) {
-            throw new Error(`Could not get cache folder paths.`);
-        }
-        core.info(`Found Cache Directory Paths: ${cacheDirectoryPaths}`);
-        // replace cache directory path with actual cache directory path
-        const actualCacheDirectoryPaths = cacheDirectoryPaths.map(path => {
-            return {
-                defaultPath: path,
-                actualPath: path.replace('C:', 'D:').replace('c:', 'd:')
-            };
-        });
-        // iterate through actual cache directory paths and make links if necessary
-        for (const cachePath of actualCacheDirectoryPaths) {
-            core.info(`Trying to link ${cachePath.defaultPath} to ${cachePath.actualPath}`);
-            try {
-                // the symlink already exists, skip
-                const stats = fs_1.default.lstatSync(cachePath.defaultPath);
-                if (fs_1.default.existsSync(cachePath.defaultPath) && stats.isSymbolicLink()) {
-                    core.info(`Directory ${cachePath.defaultPath} already linked. Skipping`);
-                    continue;
-                }
-                // the directory is empty, delete it to be able to create a symlink
-                if (stats.size == 0) {
-                    fs_1.default.rmSync(cachePath.defaultPath, { recursive: true, force: true });
-                }
-                else {
-                    core.info(`Directory ${cachePath.defaultPath} is not empty. Skipping`);
-                    continue;
-                }
-                // create a parent directory where the link will be created
-                fs_1.default.mkdirSync(path.dirname(cachePath.defaultPath), { recursive: true });
-                // create the target directory if it doesn't exist yet
-                if (!fs_1.default.existsSync(cachePath.actualPath)) {
-                    core.info(`Actual path ${cachePath.actualPath} does not exist. Creating`);
-                    fs_1.default.mkdirSync(cachePath.actualPath, { recursive: true });
-                }
-                fs_1.default.symlinkSync(cachePath.actualPath, cachePath.defaultPath, 'junction');
-                core.info(`Created link ${cachePath.defaultPath} => ${cachePath.actualPath}`);
-            }
-            catch (err) {
-                core.info(`Failed to link ${cachePath.defaultPath} to ${cachePath.actualPath}`);
-                core.info('Error: ' + err);
-            }
-        }
         // make outer code to continue using toolcache as if it were installed on c:
         // restore toolcache root to default drive c:
         process.env['RUNNER_TOOL_CACHE'] = defaultToolCacheRoot;

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -88401,22 +88401,28 @@ function cacheWindowsDir(extPath, tool, version, arch) {
         // iterate through actual cache directory paths and make links if necessary
         for (const cachePath of actualCacheDirectoryPaths) {
             core.info(`Trying to link ${cachePath.defaultPath} to ${cachePath.actualPath}`);
-            if (!fs_1.default.existsSync(cachePath.actualPath)) {
-                core.info(`Creating directory ${cachePath.actualPath}`);
-                fs_1.default.mkdirSync(path.dirname(cachePath.actualPath), { recursive: true });
+            try {
+                if (!fs_1.default.existsSync(cachePath.actualPath)) {
+                    core.info(`Creating directory ${cachePath.actualPath}`);
+                    fs_1.default.mkdirSync(path.dirname(cachePath.actualPath), { recursive: true });
+                }
+                else {
+                    core.info(`Directory ${cachePath.actualPath} already exists`);
+                }
+                // check if the default path is a symlink
+                const isSymlink = fs_1.default.lstatSync(cachePath.defaultPath).isSymbolicLink();
+                if (isSymlink) {
+                    core.info(`Default path is symlink ${cachePath.defaultPath} => ${fs_1.default.readlinkSync(cachePath.defaultPath)}`);
+                }
+                else {
+                    core.info(`Default path is not a symlink ${cachePath.defaultPath}`);
+                    fs_1.default.symlinkSync(cachePath.actualPath, cachePath.defaultPath, 'junction');
+                    core.info(`Created link ${cachePath.defaultPath} => ${cachePath.actualPath}`);
+                }
             }
-            else {
-                core.info(`Directory ${cachePath.actualPath} already exists`);
-            }
-            // make sure the link is pointing to the actual cache directory
-            const symlinkTarget = fs_1.default.readlinkSync(cachePath.defaultPath);
-            core.info(`Symlink target: ${symlinkTarget}`);
-            if (symlinkTarget !== "") {
-                core.info(`Found link ${cachePath.defaultPath} => ${symlinkTarget}`);
-            }
-            else {
-                fs_1.default.symlinkSync(cachePath.actualPath, cachePath.defaultPath, 'junction');
-                core.info(`Created link ${cachePath.defaultPath} => ${cachePath.actualPath}`);
+            catch (err) {
+                core.info(`Failed to link ${cachePath.defaultPath} to ${cachePath.actualPath}`);
+                core.info('Error: ' + err);
             }
         }
         // make outer code to continue using toolcache as if it were installed on c:

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -88091,6 +88091,18 @@ const setWindowsCacheDirectories = () => __awaiter(void 0, void 0, void 0, funct
     }
     const setModOutput = yield (0, cache_utils_1.getCommandOutput)(`go env -w GOMODCACHE=${goModCache}`);
     core.info(`go env -w GOMODCACHE output: ${setModOutput}`);
+    let goTmpDir = yield (0, cache_utils_1.getCommandOutput)(`go env GOTMPDIR`);
+    core.info(`GOTMPDIR: ${goTmpDir}`);
+    if (!goTmpDir || goTmpDir === '') {
+        goTmpDir = 'D:\\gotmp';
+    }
+    goTmpDir = goTmpDir.replace('C:', 'D:').replace('c:', 'd:');
+    if (!fs_1.default.existsSync(goTmpDir)) {
+        core.info(`${goTmpDir} does not exist. Creating`);
+        fs_1.default.mkdirSync(goTmpDir, { recursive: true });
+    }
+    const setGoTmpOutput = yield (0, cache_utils_1.getCommandOutput)(`go env -w GOTMPDIR=${goTmpDir}`);
+    core.info(`go env -w GOTMPDIR output: ${setGoTmpOutput}`);
 });
 exports.setWindowsCacheDirectories = setWindowsCacheDirectories;
 const findDependencyFile = (packageManager) => {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -88390,6 +88390,7 @@ function cacheWindowsDir(extPath, tool, version, arch) {
         if (!cacheDirectoryPaths) {
             throw new Error(`Could not get cache folder paths.`);
         }
+        core.info(`Found Cache Directory Paths: ${cacheDirectoryPaths}`);
         // replace cache directory path with actual cache directory path
         const actualCacheDirectoryPaths = cacheDirectoryPaths.map(path => {
             return {
@@ -88400,6 +88401,7 @@ function cacheWindowsDir(extPath, tool, version, arch) {
         // iterate through actual cache directory paths and make links
         for (const cachePath of actualCacheDirectoryPaths) {
             if (!fs_1.default.existsSync(cachePath.actualPath)) {
+                core.info(`Creating directory ${cachePath.actualPath}`);
                 fs_1.default.mkdirSync(path.dirname(cachePath.actualPath), { recursive: true });
             }
             fs_1.default.symlinkSync(cachePath.actualPath, cachePath.defaultPath, 'junction');

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -88400,21 +88400,23 @@ function cacheWindowsDir(extPath, tool, version, arch) {
         });
         // iterate through actual cache directory paths and make links if necessary
         for (const cachePath of actualCacheDirectoryPaths) {
+            core.info(`Trying to link ${cachePath.defaultPath} to ${cachePath.actualPath}`);
             if (!fs_1.default.existsSync(cachePath.actualPath)) {
                 core.info(`Creating directory ${cachePath.actualPath}`);
                 fs_1.default.mkdirSync(path.dirname(cachePath.actualPath), { recursive: true });
             }
             else {
                 core.info(`Directory ${cachePath.actualPath} already exists`);
-                // make sure the link is pointing to the actual cache directory
-                const symlinkTarget = fs_1.default.readlinkSync(cachePath.defaultPath);
-                if (symlinkTarget !== "") {
-                    core.info(`Found link ${cachePath.defaultPath} => ${symlinkTarget}`);
-                }
-                else {
-                    fs_1.default.symlinkSync(cachePath.actualPath, cachePath.defaultPath, 'junction');
-                    core.info(`Created link ${cachePath.defaultPath} => ${cachePath.actualPath}`);
-                }
+            }
+            // make sure the link is pointing to the actual cache directory
+            const symlinkTarget = fs_1.default.readlinkSync(cachePath.defaultPath);
+            core.info(`Symlink target: ${symlinkTarget}`);
+            if (symlinkTarget !== "") {
+                core.info(`Found link ${cachePath.defaultPath} => ${symlinkTarget}`);
+            }
+            else {
+                fs_1.default.symlinkSync(cachePath.actualPath, cachePath.defaultPath, 'junction');
+                core.info(`Created link ${cachePath.defaultPath} => ${cachePath.actualPath}`);
             }
         }
         // make outer code to continue using toolcache as if it were installed on c:

--- a/src/cache-restore.ts
+++ b/src/cache-restore.ts
@@ -6,8 +6,12 @@ import fs from 'fs';
 
 import {Outputs, State} from './constants';
 import {PackageManagerInfo} from './package-managers';
-import {getCacheDirectoryPath, getCommandOutput, getPackageManagerInfo} from './cache-utils';
-import os from "os";
+import {
+  getCacheDirectoryPath,
+  getCommandOutput,
+  getPackageManagerInfo
+} from './cache-utils';
+import os from 'os';
 
 export const restoreCache = async (
   versionSpec: string,
@@ -75,8 +79,27 @@ export const setWindowsCacheDirectories = async () => {
     fs.mkdirSync(goModCache, {recursive: true});
   }
 
-  const setModOutput = await getCommandOutput(`go env -w GOMODCACHE=${goModCache}`);
+  const setModOutput = await getCommandOutput(
+    `go env -w GOMODCACHE=${goModCache}`
+  );
   core.info(`go env -w GOMODCACHE output: ${setModOutput}`);
+
+  let goTmpDir = await getCommandOutput(`go env GOTMPDIR`);
+  core.info(`GOTMPDIR: ${goTmpDir}`);
+  if (!goTmpDir || goTmpDir === '') {
+    goTmpDir = 'D:\\gotmp';
+  }
+  goTmpDir = goTmpDir.replace('C:', 'D:').replace('c:', 'd:');
+
+  if (!fs.existsSync(goTmpDir)) {
+    core.info(`${goTmpDir} does not exist. Creating`);
+    fs.mkdirSync(goTmpDir, {recursive: true});
+  }
+
+  const setGoTmpOutput = await getCommandOutput(
+    `go env -w GOTMPDIR=${goTmpDir}`
+  );
+  core.info(`go env -w GOTMPDIR output: ${setGoTmpOutput}`);
 };
 
 const findDependencyFile = (packageManager: PackageManagerInfo) => {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -234,6 +234,7 @@ async function cacheWindowsDir(
 
   // iterate through actual cache directory paths and make links if necessary
   for (const cachePath of actualCacheDirectoryPaths) {
+    core.info(`Trying to link ${cachePath.defaultPath} to ${cachePath.actualPath}`);
     if (!fs.existsSync(cachePath.actualPath)) {
       core.info(`Creating directory ${cachePath.actualPath}`);
       fs.mkdirSync(path.dirname(cachePath.actualPath), {recursive: true});
@@ -242,6 +243,7 @@ async function cacheWindowsDir(
     }
     // make sure the link is pointing to the actual cache directory
     const symlinkTarget = fs.readlinkSync(cachePath.defaultPath);
+    core.info(`Symlink target: ${symlinkTarget}`);
     if (symlinkTarget !== "") {
       core.info(`Found link ${cachePath.defaultPath} => ${symlinkTarget}`);
     } else {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -7,7 +7,6 @@ import * as sys from './system';
 import fs from 'fs';
 import os from 'os';
 import {StableReleaseAlias} from './utils';
-import {getCacheDirectoryPath, getPackageManagerInfo} from './cache-utils';
 
 type InstallationType = 'dist' | 'manifest';
 
@@ -214,56 +213,6 @@ async function cacheWindowsDir(
   core.info(
     `Created link ${defaultToolCacheCompleteFile} => ${actualToolCacheCompleteFile}`
   );
-
-  const packageManager = 'default';
-  const packageManagerInfo = await getPackageManagerInfo(packageManager);
-  const cacheDirectoryPaths = await getCacheDirectoryPath(packageManagerInfo);
-  if (!cacheDirectoryPaths) {
-    throw new Error(`Could not get cache folder paths.`);
-  }
-
-  core.info(`Found Cache Directory Paths: ${cacheDirectoryPaths}`);
-
-  // replace cache directory path with actual cache directory path
-  const actualCacheDirectoryPaths = cacheDirectoryPaths.map(path => {
-    return {
-      defaultPath: path,
-      actualPath: path.replace('C:', 'D:').replace('c:', 'd:')
-    };
-  });
-
-  // iterate through actual cache directory paths and make links if necessary
-  for (const cachePath of actualCacheDirectoryPaths) {
-    core.info(`Trying to link ${cachePath.defaultPath} to ${cachePath.actualPath}`);
-    try {
-      // the symlink already exists, skip
-      const stats = fs.lstatSync(cachePath.defaultPath);
-      if (fs.existsSync(cachePath.defaultPath) && stats.isSymbolicLink()) {
-        core.info(`Directory ${cachePath.defaultPath} already linked. Skipping`);
-        continue
-      }
-      // the directory is empty, delete it to be able to create a symlink
-      if (stats.size == 0) {
-        fs.rmSync(cachePath.defaultPath, {recursive: true, force: true});
-      } else {
-        core.info(`Directory ${cachePath.defaultPath} is not empty. Skipping`);
-        continue;
-      }
-      // create a parent directory where the link will be created
-      fs.mkdirSync(path.dirname(cachePath.defaultPath), {recursive: true});
-
-      // create the target directory if it doesn't exist yet
-      if (!fs.existsSync(cachePath.actualPath)) {
-        core.info(`Actual path ${cachePath.actualPath} does not exist. Creating`);
-        fs.mkdirSync(cachePath.actualPath, {recursive: true});
-      }
-      fs.symlinkSync(cachePath.actualPath, cachePath.defaultPath, 'junction');
-      core.info(`Created link ${cachePath.defaultPath} => ${cachePath.actualPath}`);
-    } catch (err) {
-      core.info(`Failed to link ${cachePath.defaultPath} to ${cachePath.actualPath}`);
-      core.info('Error: ' + err);
-    }
-  }
 
   // make outer code to continue using toolcache as if it were installed on c:
   // restore toolcache root to default drive c:

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -228,7 +228,7 @@ async function cacheWindowsDir(
   const actualCacheDirectoryPaths = cacheDirectoryPaths.map(path => {
     return {
       defaultPath: path,
-      actualPath: path.replace('D:', 'C:').replace('d:', 'c:')
+      actualPath: path.replace('C:', 'D:').replace('c:', 'd:')
     };
   });
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -222,6 +222,8 @@ async function cacheWindowsDir(
     throw new Error(`Could not get cache folder paths.`);
   }
 
+  core.info(`Found Cache Directory Paths: ${cacheDirectoryPaths}`);
+  
   // replace cache directory path with actual cache directory path
   const actualCacheDirectoryPaths = cacheDirectoryPaths.map(path => {
     return {
@@ -233,6 +235,7 @@ async function cacheWindowsDir(
   // iterate through actual cache directory paths and make links
   for (const cachePath of actualCacheDirectoryPaths) {
     if (!fs.existsSync(cachePath.actualPath)) {
+      core.info(`Creating directory ${cachePath.actualPath}`);
       fs.mkdirSync(path.dirname(cachePath.actualPath), {recursive: true});
     }
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -239,16 +239,16 @@ async function cacheWindowsDir(
       fs.mkdirSync(path.dirname(cachePath.actualPath), {recursive: true});
     } else {
       core.info(`Directory ${cachePath.actualPath} already exists`);
-      // make sure the link is pointing to the actual cache directory
-      const symlinkTarget = fs.readlinkSync(cachePath.defaultPath);
-      if (symlinkTarget !== "") {
-        core.info(`Found link ${cachePath.defaultPath} => ${symlinkTarget}`);
-      } else {
-        fs.symlinkSync(cachePath.actualPath, cachePath.defaultPath, 'junction');
-        core.info(
-          `Created link ${cachePath.defaultPath} => ${cachePath.actualPath}`
-        );
-      }
+    }
+    // make sure the link is pointing to the actual cache directory
+    const symlinkTarget = fs.readlinkSync(cachePath.defaultPath);
+    if (symlinkTarget !== "") {
+      core.info(`Found link ${cachePath.defaultPath} => ${symlinkTarget}`);
+    } else {
+      fs.symlinkSync(cachePath.actualPath, cachePath.defaultPath, 'junction');
+      core.info(
+        `Created link ${cachePath.defaultPath} => ${cachePath.actualPath}`
+      );
     }
   }
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -223,7 +223,7 @@ async function cacheWindowsDir(
   }
 
   core.info(`Found Cache Directory Paths: ${cacheDirectoryPaths}`);
-  
+
   // replace cache directory path with actual cache directory path
   const actualCacheDirectoryPaths = cacheDirectoryPaths.map(path => {
     return {
@@ -232,17 +232,24 @@ async function cacheWindowsDir(
     };
   });
 
-  // iterate through actual cache directory paths and make links
+  // iterate through actual cache directory paths and make links if necessary
   for (const cachePath of actualCacheDirectoryPaths) {
     if (!fs.existsSync(cachePath.actualPath)) {
       core.info(`Creating directory ${cachePath.actualPath}`);
       fs.mkdirSync(path.dirname(cachePath.actualPath), {recursive: true});
+    } else {
+      core.info(`Directory ${cachePath.actualPath} already exists`);
+      // make sure the link is pointing to the actual cache directory
+      let symlinkTarget = fs.readlinkSync(cachePath.defaultPath);
+      if (symlinkTarget !== "") {
+        core.info(`Found link ${cachePath.defaultPath} => ${symlinkTarget}`);
+      } else {
+        fs.symlinkSync(cachePath.actualPath, cachePath.defaultPath, 'junction');
+        core.info(
+          `Created link ${cachePath.defaultPath} => ${cachePath.actualPath}`
+        );
+      }
     }
-
-    fs.symlinkSync(cachePath.actualPath, cachePath.defaultPath, 'junction');
-    core.info(
-      `Created link ${cachePath.defaultPath} => ${cachePath.actualPath}`
-    );
   }
 
   // make outer code to continue using toolcache as if it were installed on c:

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -237,8 +237,17 @@ async function cacheWindowsDir(
     core.info(`Trying to link ${cachePath.defaultPath} to ${cachePath.actualPath}`);
     try {
       // the symlink already exists, skip
-      if (fs.existsSync(cachePath.defaultPath) && fs.lstatSync(cachePath.defaultPath).isSymbolicLink()) {
+      const stats = fs.lstatSync(cachePath.defaultPath);
+      if (fs.existsSync(cachePath.defaultPath) && stats.isSymbolicLink()) {
+        core.info(`Directory ${cachePath.defaultPath} already linked. Skipping`);
         continue
+      }
+      // the directory is empty, delete it to be able to create a symlink
+      if (stats.size == 0) {
+        fs.rmSync(cachePath.defaultPath, {recursive: true, force: true});
+      } else {
+        core.info(`Directory ${cachePath.defaultPath} is not empty. Skipping`);
+        continue;
       }
       // create a parent directory where the link will be created
       fs.mkdirSync(path.dirname(cachePath.defaultPath), {recursive: true});

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -236,11 +236,16 @@ async function cacheWindowsDir(
   for (const cachePath of actualCacheDirectoryPaths) {
     core.info(`Trying to link ${cachePath.defaultPath} to ${cachePath.actualPath}`);
     try {
+      if (!fs.existsSync(cachePath.defaultPath)) {
+        core.info(`Default path ${cachePath.defaultPath} does not exist`);
+        core.info(`Creating directory ${cachePath.defaultPath}`);
+        fs.mkdirSync(cachePath.defaultPath, {recursive: true});
+      }
       if (!fs.existsSync(cachePath.actualPath)) {
-        core.info(`Creating directory ${cachePath.actualPath}`);
-        fs.mkdirSync(path.dirname(cachePath.actualPath), {recursive: true});
+        core.info(`Actual path ${cachePath.actualPath} does not exist. Safe to create symlink`);
       } else {
-        core.info(`Directory ${cachePath.actualPath} already exists`);
+        core.info(`Actual path ${cachePath.actualPath} already exists. Skipping symlink creation`);
+        continue;
       }
 
       // check if the default path is a symlink

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -240,7 +240,7 @@ async function cacheWindowsDir(
     } else {
       core.info(`Directory ${cachePath.actualPath} already exists`);
       // make sure the link is pointing to the actual cache directory
-      let symlinkTarget = fs.readlinkSync(cachePath.defaultPath);
+      const symlinkTarget = fs.readlinkSync(cachePath.defaultPath);
       if (symlinkTarget !== "") {
         core.info(`Found link ${cachePath.defaultPath} => ${symlinkTarget}`);
       } else {

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import * as io from '@actions/io';
 import * as installer from './installer';
 import * as semver from 'semver';
 import path from 'path';
-import {restoreCache} from './cache-restore';
+import {restoreCache, setWindowsCacheDirectories} from './cache-restore';
 import {isCacheFeatureAvailable} from './cache-utils';
 import cp from 'child_process';
 import fs from 'fs';
@@ -11,6 +11,7 @@ import os from 'os';
 
 export async function run() {
   try {
+    await setWindowsCacheDirectories();
     //
     // versionSpec is optional.  If supplied, install / use from the tool cache
     // If not supplied then problem matchers will still be setup.  Useful for self-hosted.


### PR DESCRIPTION
**Description:**
The issue with running setup-go and restoring relatively big cache files, causes the cache restore process to be very slow on Github Action Windows runners.
Similar to the change that was made in version v5.0.0 (PR https://github.com/actions/setup-go/pull/411), I've made a change to override the default `GOCACHE` and `GOMODCACHE` variables on Windows runners to be using drive D.
On average, restoring ~1.7Gb cache on Windows pipelines took about 13-15 minutes to extract.
With this change, the extraction time was reduced to ~1m.

### Restore cache logs before the change:
```
Wed, 20 Nov 2024 02:24:29 GMT Cache Size: ~1784 MB (1870225672 B)
Wed, 20 Nov 2024 02:24:30 GMT Received 1870225672 of 1870225672 (100.0%), 295.9 MBs/sec
Wed, 20 Nov 2024 02:37:21 GMT Cache restored successfully
Restore elapsed: 12 min 51 sec
```
```
Wed, 20 Nov 2024 01:38:54 GMT Cache Size: ~1784 MB (1870225672 B)
Wed, 20 Nov 2024 01:38:55 GMT Received 1870225672 of 1870225672 (100.0%), 118.7 MBs/sec
Wed, 20 Nov 2024 01:54:19 GMT Cache restored successfully
Restore elapsed: 15 min 24 sec
```

### Restore cache logs after the change:
```
Wed, 20 Nov 2024 03:38:03 GMT Cache Size: ~1780 MB (1866088667 B)
Wed, 20 Nov 2024 03:38:04 GMT Received 1866088667 of 1866088667 (100.0%), 197.3 MBs/sec 
Wed, 20 Nov 2024 03:38:59 GMT Cache restored successfully
Restore elapsed: 55 sec
```
```
Wed, 20 Nov 2024 03:38:10 GMT Cache Size: ~1780 MB (1866088667 B)
Wed, 20 Nov 2024 03:38:11 GMT Received 1866088667 of 1866088667 (100.0%), 197.6 MBs/sec
Wed, 20 Nov 2024 03:39:06 GMT Cache restored successfully
Restore elapsed: 55 sec
```
```
Wed, 20 Nov 2024 04:04:07 GMT Cache Size: ~1780 MB (1866088667 B)
Wed, 20 Nov 2024 04:04:07 GMT Received 1866088667 of 1866088667 (100.0%), 88.8 MBs/sec
Wed, 20 Nov 2024 04:05:05 GMT Cache restored successfully
Restore elapsed: 1 min 2 sec
```

## Solution:
At first, I tried to implement a solution similar to #411 by using symlink, however, during testing, it was clear that the `GOCACHE` and `GOMODCACHE` directories were created early by the tooling, which did not present an easy way to create symlinks without deleting the already in-use directories and introducing bigger code changes.

The solution to override the path for env vars as early as possible only on Windows runners is easier.

This PR adds the code to make this change by default for Windows runners, this "workaround" is possible to use via the Github Action code itself, by manually overriding the env vars.
Preferably, this change would be accepted and merged (after review of course), so users can enjoy this improvement by default without manually modifying each and every Github action.

**Related issue:**
Numerous related issues were raised regarding this issue, some improvements were made to address it.
- https://github.com/actions/setup-go/issues/495
- https://github.com/actions/setup-go/issues/240
- https://github.com/actions/setup-go/pull/411

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.