### PR TITLE
Update self-hosted environment validation and bump undici version

### DIFF
--- a/.licenses/npm/undici.dep.yml
+++ b/.licenses/npm/undici.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: undici
-version: 5.28.4
+version: 5.28.5
 type: npm
 summary: An HTTP/1.1 client, written from scratch for Node.js
 homepage: https://undici.nodejs.org

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,0 +1,52 @@
+import {isSelfHosted} from '../src/utils';
+
+describe('utils', () => {
+  describe('isSelfHosted', () => {
+    let AGENT_ISSELFHOSTED: string | undefined;
+    let RUNNER_ENVIRONMENT: string | undefined;
+
+    beforeEach(() => {
+      AGENT_ISSELFHOSTED = process.env['AGENT_ISSELFHOSTED'];
+      delete process.env['AGENT_ISSELFHOSTED'];
+      RUNNER_ENVIRONMENT = process.env['RUNNER_ENVIRONMENT'];
+      delete process.env['RUNNER_ENVIRONMENT'];
+    });
+
+    afterEach(() => {
+      if (AGENT_ISSELFHOSTED === undefined) {
+        delete process.env['AGENT_ISSELFHOSTED'];
+      } else {
+        process.env['AGENT_ISSELFHOSTED'] = AGENT_ISSELFHOSTED;
+      }
+      if (RUNNER_ENVIRONMENT === undefined) {
+        delete process.env['RUNNER_ENVIRONMENT'];
+      } else {
+        process.env['RUNNER_ENVIRONMENT'] = RUNNER_ENVIRONMENT;
+      }
+    });
+
+    it('isSelfHosted should be true if no environment variables set', () => {
+      expect(isSelfHosted()).toBeTruthy();
+    });
+
+    it('isSelfHosted should be true if environment variable is not set to denote GitHub hosted', () => {
+      process.env['RUNNER_ENVIRONMENT'] = 'some';
+      expect(isSelfHosted()).toBeTruthy();
+    });
+
+    it('isSelfHosted should be true if environment variable set to denote Azure Pipelines self hosted', () => {
+      process.env['AGENT_ISSELFHOSTED'] = '1';
+      expect(isSelfHosted()).toBeTruthy();
+    });
+
+    it('isSelfHosted should be false if environment variable set to denote GitHub hosted', () => {
+      process.env['RUNNER_ENVIRONMENT'] = 'github-hosted';
+      expect(isSelfHosted()).toBeFalsy();
+    });
+
+    it('isSelfHosted should be false if environment variable is not set to denote Azure Pipelines self hosted', () => {
+      process.env['AGENT_ISSELFHOSTED'] = 'some';
+      expect(isSelfHosted()).toBeFalsy();
+    });
+  });
+});

--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -68310,6 +68310,14 @@ const { isUint8Array, isArrayBuffer } = __nccwpck_require__(9830)
 const { File: UndiciFile } = __nccwpck_require__(8511)
 const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(685)
 
+let random
+try {
+  const crypto = __nccwpck_require__(6005)
+  random = (max) => crypto.randomInt(0, max)
+} catch {
+  random = (max) => Math.floor(Math.random(max))
+}
+
 let ReadableStream = globalThis.ReadableStream
 
 /** @type {globalThis['File']} */
@@ -68395,7 +68403,7 @@ function extractBody (object, keepalive = false) {
     // Set source to a copy of the bytes held by object.
     source = new Uint8Array(object.buffer.slice(object.byteOffset, object.byteOffset + object.byteLength))
   } else if (util.isFormDataLike(object)) {
-    const boundary = `----formdata-undici-0${`${Math.floor(Math.random() * 1e11)}`.padStart(11, '0')}`
+    const boundary = `----formdata-undici-0${`${random(1e11)}`.padStart(11, '0')}`
     const prefix = `--${boundary}\r\nContent-Disposition: form-data`
 
     /*! formdata-polyfill. MIT License. Jimmy Wärting <https://jimmy.warting.se/opensource> */
@@ -89747,6 +89755,14 @@ module.exports = require("https");
 
 "use strict";
 module.exports = require("net");
+
+/***/ }),
+
+/***/ 6005:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("node:crypto");
 
 /***/ }),
 

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -96642,15 +96642,15 @@ var StableReleaseAlias;
     StableReleaseAlias["Stable"] = "stable";
     StableReleaseAlias["OldStable"] = "oldstable";
 })(StableReleaseAlias || (exports.StableReleaseAlias = StableReleaseAlias = {}));
-const isSelfHosted = () => process.env['AGENT_ISSELFHOSTED'] === '1' ||
-    (process.env['AGENT_ISSELFHOSTED'] === undefined &&
-        process.env['RUNNER_ENVIRONMENT'] !== 'github-hosted');
+const isSelfHosted = () => process.env['RUNNER_ENVIRONMENT'] !== 'github-hosted' &&
+    (process.env['AGENT_ISSELFHOSTED'] === '1' ||
+        process.env['AGENT_ISSELFHOSTED'] === undefined);
 exports.isSelfHosted = isSelfHosted;
 /* the above is simplified from:
-    process.env['RUNNER_ENVIRONMENT'] === undefined && process.env['AGENT_ISSELFHOSTED'] === '1'
+    process.env['RUNNER_ENVIRONMENT'] !== 'github-hosted' && process.env['AGENT_ISSELFHOSTED'] === '1'
     ||
-    process.env['AGENT_ISSELFHOSTED'] === undefined && process.env['RUNNER_ENVIRONMENT'] !== 'github-hosted'
-     */
+    process.env['RUNNER_ENVIRONMENT'] !== 'github-hosted' && process.env['AGENT_ISSELFHOSTED'] === undefined
+*/
 
 
 /***/ }),

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -74598,6 +74598,14 @@ const { isUint8Array, isArrayBuffer } = __nccwpck_require__(9830)
 const { File: UndiciFile } = __nccwpck_require__(8511)
 const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(685)
 
+let random
+try {
+  const crypto = __nccwpck_require__(6005)
+  random = (max) => crypto.randomInt(0, max)
+} catch {
+  random = (max) => Math.floor(Math.random(max))
+}
+
 let ReadableStream = globalThis.ReadableStream
 
 /** @type {globalThis['File']} */
@@ -74683,7 +74691,7 @@ function extractBody (object, keepalive = false) {
     // Set source to a copy of the bytes held by object.
     source = new Uint8Array(object.buffer.slice(object.byteOffset, object.byteOffset + object.byteLength))
   } else if (util.isFormDataLike(object)) {
-    const boundary = `----formdata-undici-0${`${Math.floor(Math.random() * 1e11)}`.padStart(11, '0')}`
+    const boundary = `----formdata-undici-0${`${random(1e11)}`.padStart(11, '0')}`
     const prefix = `--${boundary}\r\nContent-Disposition: form-data`
 
     /*! formdata-polyfill. MIT License. Jimmy Wärting <https://jimmy.warting.se/opensource> */
@@ -96121,8 +96129,7 @@ function cacheWindowsDir(extPath, tool, version, arch) {
         if (os_1.default.platform() !== 'win32')
             return false;
         // make sure the action runs in the hosted environment
-        if (process.env['RUNNER_ENVIRONMENT'] !== 'github-hosted' &&
-            process.env['AGENT_ISSELFHOSTED'] === '1')
+        if ((0, utils_1.isSelfHosted)())
             return false;
         const defaultToolCacheRoot = process.env['RUNNER_TOOL_CACHE'];
         if (!defaultToolCacheRoot)
@@ -96629,12 +96636,21 @@ exports.getArch = getArch;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.StableReleaseAlias = void 0;
+exports.isSelfHosted = exports.StableReleaseAlias = void 0;
 var StableReleaseAlias;
 (function (StableReleaseAlias) {
     StableReleaseAlias["Stable"] = "stable";
     StableReleaseAlias["OldStable"] = "oldstable";
 })(StableReleaseAlias || (exports.StableReleaseAlias = StableReleaseAlias = {}));
+const isSelfHosted = () => process.env['AGENT_ISSELFHOSTED'] === '1' ||
+    (process.env['AGENT_ISSELFHOSTED'] === undefined &&
+        process.env['RUNNER_ENVIRONMENT'] !== 'github-hosted');
+exports.isSelfHosted = isSelfHosted;
+/* the above is simplified from:
+    process.env['RUNNER_ENVIRONMENT'] === undefined && process.env['AGENT_ISSELFHOSTED'] === '1'
+    ||
+    process.env['AGENT_ISSELFHOSTED'] === undefined && process.env['RUNNER_ENVIRONMENT'] !== 'github-hosted'
+     */
 
 
 /***/ }),
@@ -96748,6 +96764,14 @@ module.exports = require("https");
 
 "use strict";
 module.exports = require("net");
+
+/***/ }),
+
+/***/ 6005:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("node:crypto");
 
 /***/ }),
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5892,9 +5892,10 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+      "version": "5.28.5",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
+      "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
+      "license": "MIT",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -6,7 +6,7 @@ import * as httpm from '@actions/http-client';
 import * as sys from './system';
 import fs from 'fs';
 import os from 'os';
-import {StableReleaseAlias} from './utils';
+import {StableReleaseAlias, isSelfHosted} from './utils';
 
 const MANIFEST_REPO_OWNER = 'actions';
 const MANIFEST_REPO_NAME = 'go-versions';
@@ -180,11 +180,7 @@ async function cacheWindowsDir(
   if (os.platform() !== 'win32') return false;
 
   // make sure the action runs in the hosted environment
-  if (
-    process.env['RUNNER_ENVIRONMENT'] !== 'github-hosted' &&
-    process.env['AGENT_ISSELFHOSTED'] === '1'
-  )
-    return false;
+  if (isSelfHosted()) return false;
 
   const defaultToolCacheRoot = process.env['RUNNER_TOOL_CACHE'];
   if (!defaultToolCacheRoot) return false;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,11 +4,11 @@ export enum StableReleaseAlias {
 }
 
 export const isSelfHosted = (): boolean =>
-  process.env['AGENT_ISSELFHOSTED'] === '1' ||
-  (process.env['AGENT_ISSELFHOSTED'] === undefined &&
-    process.env['RUNNER_ENVIRONMENT'] !== 'github-hosted');
+  process.env['RUNNER_ENVIRONMENT'] !== 'github-hosted' &&
+  (process.env['AGENT_ISSELFHOSTED'] === '1' ||
+    process.env['AGENT_ISSELFHOSTED'] === undefined);
 /* the above is simplified from:
-    process.env['RUNNER_ENVIRONMENT'] === undefined && process.env['AGENT_ISSELFHOSTED'] === '1'
+    process.env['RUNNER_ENVIRONMENT'] !== 'github-hosted' && process.env['AGENT_ISSELFHOSTED'] === '1'
     ||
-    process.env['AGENT_ISSELFHOSTED'] === undefined && process.env['RUNNER_ENVIRONMENT'] !== 'github-hosted'
-     */
+    process.env['RUNNER_ENVIRONMENT'] !== 'github-hosted' && process.env['AGENT_ISSELFHOSTED'] === undefined
+*/

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,3 +2,13 @@ export enum StableReleaseAlias {
   Stable = 'stable',
   OldStable = 'oldstable'
 }
+
+export const isSelfHosted = (): boolean =>
+  process.env['AGENT_ISSELFHOSTED'] === '1' ||
+  (process.env['AGENT_ISSELFHOSTED'] === undefined &&
+    process.env['RUNNER_ENVIRONMENT'] !== 'github-hosted');
+/* the above is simplified from:
+    process.env['RUNNER_ENVIRONMENT'] === undefined && process.env['AGENT_ISSELFHOSTED'] === '1'
+    ||
+    process.env['AGENT_ISSELFHOSTED'] === undefined && process.env['RUNNER_ENVIRONMENT'] !== 'github-hosted'
+     */


### PR DESCRIPTION
**Description:**
This PR includes the following updates:
- Update the validation logic for self-hosted environments to ensure accurate detection and handling of self-hosted setups.
- Bump [undici](https://github.com/nodejs/undici) from 5.28.4 to 5.28.5.

**Related issue:**
#550 

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.