### PR TITLE
Add the 'always-cache' option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,9 @@ inputs:
   cache:
     description: Used to specify whether caching is needed. Set to true, if you'd like to enable caching.
     default: true
+  always-cache:
+    description: If enabled, stores the cache even in the event of a cache hit. This will result in a larger Go build (and test) cache, but less repeated test runs.
+    default: false
   cache-dependency-path:
     description: 'Used to specify the path to a dependency file - go.sum'
   architecture:

--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -89440,7 +89440,7 @@ function run(earlyExit) {
         try {
             const cacheInput = core.getBooleanInput('cache');
             if (cacheInput) {
-                yield cachePackages();
+                yield cachePackages(core.getBooleanInput('always-cache'));
                 if (earlyExit) {
                     process.exit(0);
                 }
@@ -89459,7 +89459,7 @@ function run(earlyExit) {
     });
 }
 exports.run = run;
-const cachePackages = () => __awaiter(void 0, void 0, void 0, function* () {
+const cachePackages = (...args_1) => __awaiter(void 0, [...args_1], void 0, function* (alwaysCache = false) {
     const packageManager = 'default';
     const state = core.getState(constants_1.State.CacheMatchedKey);
     const primaryKey = core.getState(constants_1.State.CachePrimaryKey);
@@ -89477,8 +89477,8 @@ const cachePackages = () => __awaiter(void 0, void 0, void 0, function* () {
         core.info('Primary key was not generated. Please check the log messages above for more errors or information');
         return;
     }
-    if (primaryKey === state) {
-        core.info(`Cache hit occurred on the primary key ${primaryKey}, not saving cache.`);
+    if (primaryKey === state && !alwaysCache) {
+        core.info(`Cache hit occurred on the primary key ${primaryKey} and always-cache is 'false', not saving cache.`);
         return;
     }
     const cacheId = yield cache.saveCache(cachePaths, primaryKey);

--- a/src/cache-save.ts
+++ b/src/cache-save.ts
@@ -19,7 +19,7 @@ export async function run(earlyExit?: boolean) {
   try {
     const cacheInput = core.getBooleanInput('cache');
     if (cacheInput) {
-      await cachePackages();
+      await cachePackages(core.getBooleanInput('always-cache'));
 
       if (earlyExit) {
         process.exit(0);
@@ -37,7 +37,7 @@ export async function run(earlyExit?: boolean) {
   }
 }
 
-const cachePackages = async () => {
+const cachePackages = async (alwaysCache: boolean = false) => {
   const packageManager = 'default';
 
   const state = core.getState(State.CacheMatchedKey);
@@ -71,9 +71,9 @@ const cachePackages = async () => {
     return;
   }
 
-  if (primaryKey === state) {
+  if (primaryKey === state && !alwaysCache) {
     core.info(
-      `Cache hit occurred on the primary key ${primaryKey}, not saving cache.`
+      `Cache hit occurred on the primary key ${primaryKey} and always-cache is 'false', not saving cache.`
     );
     return;
   }


### PR DESCRIPTION
**Description:**
The `always-cache` option will always update the cache, even in the event of a cache hit. This is particularly useful for larger projects with a lot of unit tests and a high volume of changes.

**Related issue:**
https://github.com/actions/setup-go/issues/569

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.