### PR TITLE
Fall back to downloading from go.dev/dl instead of storage.googleapis.com/golang

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See full release notes on the [releases page](https://github.com/actions/setup-g
 The action will first check the local cache for a version match. If a version is not found locally, it will pull it from
 the `main` branch of the [go-versions](https://github.com/actions/go-versions/blob/main/versions-manifest.json)
 repository. On miss or failure, it will fall back to downloading directly
-from [go dist](https://dl.google.com/go). To change the default behavior, please use
+from [go dist](https://go.dev/dl). To change the default behavior, please use
 the [check-latest input](#check-latest-version).
 
 **Note:** The `setup-go` action uses executable binaries which are built by Golang side. The action does not build
@@ -240,7 +240,7 @@ When dynamically downloading Go distributions, `setup-go` downloads distribution
 
 These calls to `actions/go-versions` are made via unauthenticated requests, which are limited to [60 requests per hour per IP](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting).
 If more requests are made within the time frame, then the action leverages the `raw API` to retrieve the version-manifest. This approach does not impose a rate limit and hence facilitates unrestricted consumption. This is particularly beneficial for GHES runners, which often share the same IP, to avoid the quick exhaustion of the unauthenticated rate limit.
-If that fails as well the action will try to download versions directly from https://dl.google.com/go.
+If that fails as well the action will try to download versions directly from https://go.dev/dl.
 
 If that fails as well you can get a higher rate limit with [generating a personal access token on github.com](https://github.com/settings/tokens/new) and passing it as the `token` input to the action:
 

--- a/__tests__/setup-go.test.ts
+++ b/__tests__/setup-go.test.ts
@@ -389,7 +389,7 @@ describe('setup-go', () => {
 
     const expPath = path.win32.join(toolPath, 'bin');
     expect(dlSpy).toHaveBeenCalledWith(
-      'https://dl.google.com/go/go1.13.1.windows-amd64.zip',
+      'https://go.dev/dl/go1.13.1.windows-amd64.zip',
       'C:\\temp\\go1.13.1.windows-amd64.zip',
       undefined
     );
@@ -946,7 +946,7 @@ use .
         const expectedUrl =
           platform === 'win32'
             ? `https://github.com/actions/go-versions/releases/download/${version}/go-${version}-${platform}-${arch}.${fileExtension}`
-            : `https://dl.google.com/go/go${version}.${osSpec}-${arch}.${fileExtension}`;
+            : `https://go.dev/dl/go${version}.${osSpec}-${arch}.${fileExtension}`;
 
         // ... but not in the local cache
         findSpy.mockImplementation(() => '');

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -94583,7 +94583,7 @@ function getInfoFromDist(versionSpec, arch) {
         if (!version) {
             return null;
         }
-        const downloadUrl = `https://dl.google.com/go/${version.files[0].filename}`;
+        const downloadUrl = `https://go.dev/dl/${version.files[0].filename}`;
         return {
             type: 'dist',
             downloadUrl: downloadUrl,

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -389,7 +389,7 @@ async function getInfoFromDist(
     return null;
   }
 
-  const downloadUrl = `https://dl.google.com/go/${version.files[0].filename}`;
+  const downloadUrl = `https://go.dev/dl/${version.files[0].filename}`;
 
   return <IGoVersionInfo>{
     type: 'dist',


### PR DESCRIPTION
**Description:**

storage.googleapis.com/golang no longer allows anonymous bucket access:

<img width="1262" height="317" alt="Image" src="https://github.com/user-attachments/assets/0d9207c6-5b95-46b2-bd93-d2860b04ee05" />

Fall back to downloading from dl.google.com/go, which is where https://go.dev/dl/ points to now.

**Related issue:**

Closes #664.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.