### PR TITLE
feat: add support for custom go-download-site input

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,79 @@ For more information about semantic versioning, see the [semver documentation](h
     
     # Architecture to install (auto-detected if not specified)
     architecture: 'x64'
+    
+    # Base URL for downloading Go distributions (default: https://github.com)
+    go-download-site: 'https://github.com'
+
+## Using Custom Download Sites
+
+For environments with restricted internet access or when using internal mirrors/proxies, you can configure the action to download Go distributions from a custom location using the `go-download-site` input.
+
+### Use Cases
+
+- **GitHub Enterprise Server** - Access Go distributions through your internal server
+- **Corporate Proxies** - Route downloads through approved proxy servers
+- **Artifact Repositories** - Use internal artifact management systems (Artifactory, Nexus, etc.)
+- **Air-Gapped Environments** - Download from pre-populated internal mirrors
+
+### Configuration
+
+```yaml
+steps:
+  - uses: actions/checkout@v5
+  - uses: actions/setup-go@v6
+    with:
+      go-version: '1.21'
+      go-download-site: 'https://internal-artifactory.company.com/github-proxy'
+  - run: go version
 ```
+
+**How it works:**
+
+The action will replace the default `https://github.com` base URL with your custom download site. For example:
+
+- **Default URL:**
+  ```
+  https://github.com/actions/go-versions/releases/download/1.21.13-10277905115/go-1.21.13-linux-x64.tar.gz
+  ```
+
+- **Custom URL (with `go-download-site: 'https://internal-artifactory.company.com/github-proxy'`):**
+  ```
+  https://internal-artifactory.company.com/github-proxy/actions/go-versions/releases/download/1.21.13-10277905115/go-1.21.13-linux-x64.tar.gz
+  ```
+
+### Requirements
+
+Your custom download site must:
+1. Mirror the same directory structure as GitHub's go-versions repository
+2. Host the pre-built Go distribution archives
+3. Be accessible from your runners
+
+### Example: Using with JFrog Artifactory
+
+```yaml
+steps:
+  - uses: actions/checkout@v5
+  - uses: actions/setup-go@v6
+    with:
+      go-version: '1.23'
+      go-download-site: 'https://artifactory.internal.company.com/artifactory/github-mirror'
+  - run: go version
+```
+
+### Example: Using with GitHub Enterprise Server Proxy
+
+```yaml
+steps:
+  - uses: actions/checkout@v5
+  - uses: actions/setup-go@v6
+    with:
+      go-version: '1.22'
+      go-download-site: 'https://ghes.company.com/github-com-proxy'
+  - run: go version
+```
+
+> **Note:** The `go-download-site` parameter only affects downloads from the go-versions repository. Direct downloads from go.dev (fallback mechanism) are not affected by this setting.
 
 ## Using setup-go on GHES
 

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
     description: 'Used to specify the path to a dependency file - go.sum'
   architecture:
     description: 'Target architecture for Go to use. Examples: x86, x64. Will use system architecture by default.'
+  go-download-site:
+    description: 'Base URL for downloading Go distributions. Useful for GitHub Enterprise or when using a proxy/mirror. Defaults to https://github.com'
+    default: 'https://github.com'
 outputs:
   go-version:
     description: 'The installed Go version. Useful when given a version range as input.'

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -42,7 +42,8 @@ export async function getGo(
   versionSpec: string,
   checkLatest: boolean,
   auth: string | undefined,
-  arch: Architecture = os.arch() as Architecture
+  arch: Architecture = os.arch() as Architecture,
+  goDownloadSite: string = 'https://github.com'
 ) {
   let manifest: tc.IToolRelease[] | undefined;
   const osPlat: string = os.platform();
@@ -80,7 +81,8 @@ export async function getGo(
       true,
       auth,
       arch,
-      manifest
+      manifest,
+      goDownloadSite
     );
     if (resolvedVersion) {
       versionSpec = resolvedVersion;
@@ -105,7 +107,7 @@ export async function getGo(
   // Try download from internal distribution (popular versions only)
   //
   try {
-    info = await getInfoFromManifest(versionSpec, true, auth, arch, manifest);
+    info = await getInfoFromManifest(versionSpec, true, auth, arch, manifest, goDownloadSite);
     if (info) {
       downloadPath = await installGoVersion(info, auth, arch);
     } else {
@@ -155,7 +157,8 @@ async function resolveVersionFromManifest(
   stable: boolean,
   auth: string | undefined,
   arch: Architecture,
-  manifest: tc.IToolRelease[] | undefined
+  manifest: tc.IToolRelease[] | undefined,
+  goDownloadSite: string = 'https://github.com'
 ): Promise<string | undefined> {
   try {
     const info = await getInfoFromManifest(
@@ -163,7 +166,8 @@ async function resolveVersionFromManifest(
       stable,
       auth,
       arch,
-      manifest
+      manifest,
+      goDownloadSite
     );
     return info?.resolvedVersion;
   } catch (err) {
@@ -357,7 +361,8 @@ export async function getInfoFromManifest(
   stable: boolean,
   auth: string | undefined,
   arch: Architecture = os.arch() as Architecture,
-  manifest?: tc.IToolRelease[] | undefined
+  manifest?: tc.IToolRelease[] | undefined,
+  goDownloadSite: string = 'https://github.com'
 ): Promise<IGoVersionInfo | null> {
   let info: IGoVersionInfo | null = null;
   if (!manifest) {
@@ -373,7 +378,8 @@ export async function getInfoFromManifest(
     info = <IGoVersionInfo>{};
     info.type = 'manifest';
     info.resolvedVersion = rel.version;
-    info.downloadUrl = rel.files[0].download_url;
+    // Replace the default github.com URL with the custom download site
+    info.downloadUrl = rel.files[0].download_url.replace('https://github.com', goDownloadSite);
     info.fileName = rel.files[0].filename;
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,12 +33,14 @@ export async function run() {
       const auth = !token ? undefined : `token ${token}`;
 
       const checkLatest = core.getBooleanInput('check-latest');
+      const goDownloadSite = core.getInput('go-download-site') || 'https://github.com';
 
       const installDir = await installer.getGo(
         versionSpec,
         checkLatest,
         auth,
-        arch
+        arch,
+        goDownloadSite
       );
 
       const installDirVersion = path.basename(path.dirname(installDir));


### PR DESCRIPTION
This adds a new `go-download-site` input parameter that allows users to specify a custom base URL for downloading Go distributions. This is particularly useful for GitHub Enterprise Server (GHES) environments, corporate proxies, or air-gapped setups where direct access to github.com is restricted.

Changes:
- Added `go-download-site` input to `action.yml` (default: `https://github.com`)
- Updated `installer.ts` to replace the default GitHub URL with the provided custom site URL
- Updated `main.ts` to pass the input to the installer
- Added documentation in `README.md` with examples for Artifactory and GHES proxies

Resolves #296

**Description:**
Describe your changes.

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.