### PR TITLE
Fix Node.js version in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ outputs:
   cache-hit:
     description: 'A boolean value to indicate if a cache was hit'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/setup/index.js'
   post: 'dist/cache-save/index.js'
   post-if: success()


### PR DESCRIPTION
**Description:**

It looks like the Node.js version specified in action.yml was left behind when we upgraded the project to Node.js 24. This commit updates action.yml to reflect the correct Node.js version.

**Related issue:**

- #624

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.