### PR TITLE
support rc version such as `go 1.26rc1`

### DIFF
--- a/__tests__/setup-go.test.ts
+++ b/__tests__/setup-go.test.ts
@@ -710,6 +710,41 @@ describe('setup-go', () => {
     expect(im.makeSemver('1.13.1')).toBe('1.13.1');
   });
 
+  describe('normalizeVersionSpec', () => {
+    it('converts Go-style prerelease to semver format', () => {
+      expect(im.normalizeVersionSpec('1.14rc1')).toBe('1.14.0-rc.1');
+      expect(im.normalizeVersionSpec('1.14beta1')).toBe('1.14.0-beta.1');
+      expect(im.normalizeVersionSpec('1.21rc2')).toBe('1.21.0-rc.2');
+    });
+
+    it('preserves range prefixes when converting', () => {
+      expect(im.normalizeVersionSpec('^1.14rc1')).toBe('^1.14.0-rc.1');
+      expect(im.normalizeVersionSpec('~1.14beta1')).toBe('~1.14.0-beta.1');
+      expect(im.normalizeVersionSpec('>=1.14rc1')).toBe('>=1.14.0-rc.1');
+      expect(im.normalizeVersionSpec('>1.14rc1')).toBe('>1.14.0-rc.1');
+      expect(im.normalizeVersionSpec('<=1.14rc1')).toBe('<=1.14.0-rc.1');
+      expect(im.normalizeVersionSpec('<1.14rc1')).toBe('<1.14.0-rc.1');
+      expect(im.normalizeVersionSpec('=1.14rc1')).toBe('=1.14.0-rc.1');
+    });
+
+    it('preserves versions without Go-style prerelease', () => {
+      expect(im.normalizeVersionSpec('1.13')).toBe('1.13');
+      expect(im.normalizeVersionSpec('1.13.7')).toBe('1.13.7');
+      expect(im.normalizeVersionSpec('^1.13.6')).toBe('^1.13.6');
+      expect(im.normalizeVersionSpec('>=1.13')).toBe('>=1.13');
+    });
+
+    it('preserves already valid semver prerelease format', () => {
+      expect(im.normalizeVersionSpec('1.14.0-rc.1')).toBe('1.14.0-rc.1');
+      expect(im.normalizeVersionSpec('^1.14.0-beta.1')).toBe('^1.14.0-beta.1');
+    });
+
+    it('does not match false positives like "traced"', () => {
+      // "traced" contains "rc" but should not be treated as prerelease
+      expect(im.normalizeVersionSpec('1.13traced')).toBe('1.13traced');
+    });
+  });
+
   describe('check-latest flag', () => {
     it("use local version and don't check manifest if check-latest is not specified", async () => {
       os.platform = 'linux';

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -94801,16 +94801,14 @@ function getVersionsDist(dlUrl) {
 // 1.13 => 1.13 (preserved for range matching)
 // 1.14rc1 => 1.14.0-rc.1
 // ^1.14rc1 => ^1.14.0-rc.1
-// ~1.14beta1 => ~1.14.0-beta.1
+// >=1.14beta1 => >=1.14.0-beta.1
 function normalizeVersionSpec(versionSpec) {
-    var _a;
-    const rangePrefix = ((_a = versionSpec.match(/^[~^]/)) === null || _a === void 0 ? void 0 : _a[0]) || '';
-    const version = versionSpec.replace(/^[~^]/, '');
-    // Only convert if it has Go-style prerelease (rc/beta without hyphen prefix)
-    const hasGoStylePrerelease = (version.includes('rc') || version.includes('beta')) &&
-        !version.includes('-rc.') &&
-        !version.includes('-beta.');
-    if (!hasGoStylePrerelease) {
+    // Match semver range prefixes: ^, ~, >, >=, <, <=, =
+    const rangePrefixMatch = versionSpec.match(/^([~^]|[<>]=?|=)/);
+    const rangePrefix = (rangePrefixMatch === null || rangePrefixMatch === void 0 ? void 0 : rangePrefixMatch[0]) || '';
+    const version = versionSpec.slice(rangePrefix.length);
+    // Only convert if it has Go-style prerelease (e.g., rc1, beta1)
+    if (!/(?:rc|beta)\d+/.test(version)) {
         return versionSpec;
     }
     return rangePrefix + makeSemver(version);

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -467,18 +467,15 @@ export async function getVersionsDist(
 // 1.13 => 1.13 (preserved for range matching)
 // 1.14rc1 => 1.14.0-rc.1
 // ^1.14rc1 => ^1.14.0-rc.1
-// ~1.14beta1 => ~1.14.0-beta.1
+// >=1.14beta1 => >=1.14.0-beta.1
 export function normalizeVersionSpec(versionSpec: string): string {
-  const rangePrefix = versionSpec.match(/^[~^]/)?.[0] || '';
-  const version = versionSpec.replace(/^[~^]/, '');
+  // Match semver range prefixes: ^, ~, >, >=, <, <=, =
+  const rangePrefixMatch = versionSpec.match(/^([~^]|[<>]=?|=)/);
+  const rangePrefix = rangePrefixMatch?.[0] || '';
+  const version = versionSpec.slice(rangePrefix.length);
 
-  // Only convert if it has Go-style prerelease (rc/beta without hyphen prefix)
-  const hasGoStylePrerelease =
-    (version.includes('rc') || version.includes('beta')) &&
-    !version.includes('-rc.') &&
-    !version.includes('-beta.');
-
-  if (!hasGoStylePrerelease) {
+  // Only convert if it has Go-style prerelease (e.g., rc1, beta1)
+  if (!/(?:rc|beta)\d+/.test(version)) {
     return versionSpec;
   }
 


### PR DESCRIPTION
**Description:**

`actions/go-setup` cannot install `go1.26rc1`:

https://github.com/sqldef/sqldef/actions/runs/20521055234/job/58956343695?pr=1066

This PR fixes it by introducing `normalizeVersionSpec()`.

With this PR, setup-go can install `1.26rc1`: https://github.com/sqldef/sqldef/actions/runs/20523447714/job/58962500134?pr=1066

**Related issue:**

(none)

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.