### PR TITLE
Update README to use go.mod rather than go.sum

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,12 +267,12 @@ steps:
 
 For advanced scenarios, use `cache-dependency-path` to specify:
 - **Multiple dependency files**: When your project has dependencies in different directories
-- **Custom locations**: When your `go.sum` files are not in the repository root
+- **Custom locations**: When your `go.mod` files are not in the repository root
 - **Monorepos**: When managing multiple Go modules in a single repository
 - **Glob patterns**: For flexible file matching
 
 ```yaml
-# Example: Monorepo with multiple go.sum files
+# Example: Monorepo with multiple go.mod files
 steps:
   - uses: actions/checkout@v6
   - uses: actions/setup-go@v6
@@ -280,19 +280,19 @@ steps:
       go-version: '1.23'
       check-latest: true
       cache-dependency-path: |
-        subdir/go.sum
-        tools/go.sum
+        subdir/go.mod
+        tools/go.mod
   - run: go run hello.go
 ```
 
 ```yaml
-# Example: Using glob patterns to match all go.sum files
+# Example: Using glob patterns to match all go.mod files
 steps:
   - uses: actions/checkout@v6
   - uses: actions/setup-go@v6
     with:
       go-version: '1.23'
-      cache-dependency-path: "**/*.sum"
+      cache-dependency-path: "**/*.mod"
   - run: go run hello.go
 ```
 
@@ -433,7 +433,7 @@ For more information about semantic versioning, see the [semver documentation](h
     cache: true
     
     # Path to dependency files for caching
-    cache-dependency-path: 'go.sum'
+    cache-dependency-path: 'go.mod'
     
     # Architecture to install (auto-detected if not specified)
     architecture: 'x64'


### PR DESCRIPTION
**Description:**
The README listed `go.sum` in several examples. This is misleading, as `go.mod` rather than `go.sum` is the correct file to use for computing a cache key.

See related issue+PR below for details.

**Related issue:**
https://github.com/actions/setup-go/issues/478
https://github.com/actions/setup-go/pull/705

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.