### PR TITLE
Add cache-write input for read-only cache mode

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
     default: true
   cache-dependency-path:
     description: 'Used to specify the path to a dependency file (e.g., go.mod, go.sum)'
+  cache-write:
+    description: 'Whether to save the cache at the end of the workflow. Set to false for cache read-only mode, useful for preventing cache poisoning from untrusted PR builds.'
+    default: true
   architecture:
     description: 'Target architecture for Go to use. Examples: x86, x64. Will use system architecture by default.'
 outputs:

--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -71548,6 +71548,11 @@ process.on('uncaughtException', e => {
 function run(earlyExit) {
     return __awaiter(this, void 0, void 0, function* () {
         try {
+            const cacheWriteEnabled = core.getInput('cache-write');
+            if (cacheWriteEnabled === 'false') {
+                core.info('Cache write is disabled (read-only mode). Skipping cache save.');
+                return;
+            }
             const cacheInput = core.getBooleanInput('cache');
             if (cacheInput) {
                 yield cachePackages();

--- a/src/cache-save.ts
+++ b/src/cache-save.ts
@@ -20,7 +20,9 @@ export async function run(earlyExit?: boolean) {
   try {
     const cacheWriteEnabled = core.getInput('cache-write');
     if (cacheWriteEnabled === 'false') {
-      core.info('Cache write is disabled (read-only mode). Skipping cache save.');
+      core.info(
+        'Cache write is disabled (read-only mode). Skipping cache save.'
+      );
       return;
     }
 

--- a/src/cache-save.ts
+++ b/src/cache-save.ts
@@ -18,6 +18,12 @@ process.on('uncaughtException', e => {
 
 export async function run(earlyExit?: boolean) {
   try {
+    const cacheWriteEnabled = core.getInput('cache-write');
+    if (cacheWriteEnabled === 'false') {
+      core.info('Cache write is disabled (read-only mode). Skipping cache save.');
+      return;
+    }
+
     const cacheInput = core.getBooleanInput('cache');
     if (cacheInput) {
       await cachePackages();


### PR DESCRIPTION
With `cache: true` (the default), this action restores and saves the module/build cache automatically. But for PR workflows, there's no way to opt into restore-only — you either get full caching or none. This is a problem for cache poisoning: an untrusted PR can write to the cache and subsequent trusted runs on main pick up the tainted content.

This adds a `cache-write` input (defaults to `true`, backward compatible). When `false`, the post-step cache save is skipped.

**Usage:**
```yaml
- uses: actions/setup-go@v6
  with:
    go-version: "1.22"
    cache-write: ${{ github.event_name != 'pull_request' }}
```

**What changed:**
- `action.yml` — new `cache-write` input
- `src/cache-save.ts` — early return when `cache-write` is `false`
- `dist/` — rebuilt

Same change going into setup-node, setup-python, setup-java, setup-dotnet.