### PR TITLE
docs: fix Microsoft build of Go link

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -426,7 +426,7 @@ The `go-download-base-url` input lets you download Go from a mirror or alternati
 
 When a custom base URL is provided, the action skips the `actions/go-versions` manifest lookup and downloads directly from the specified URL.
 
-**Using the [Microsoft build of Go](https://github.com/nicholasgasior/microsoft-go):**
+**Using the [Microsoft build of Go](https://github.com/microsoft/go):**
 
 ```yaml
 steps:


### PR DESCRIPTION
**Description:**
Fixes the URL to the Microsoft build of Go

**Related issue:**
n/a

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.